### PR TITLE
fix: error serialization on native image

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -4,10 +4,11 @@ cd certeasy-core
 cd ../certeasy-bouncycastle
 ./mvnw clean install
 cd ../certeasy-backend-app
-./mvnw install -Dnative -DskipTests -Dquarkus.native.container-build=true
-mkdir /tmp/certeasy-build
-cp Dockerfile /tmp/certeasy-build
-cp target/*-runner /tmp/certeasy-build/
+./mvnw package -Dnative -DskipTests -Dquarkus.native.container-build=true
+cd ../
+mkdir -p /tmp/certeasy-build
+cp Dockerfile /tmp/certeasy-build/
+cp certeasy-backend-app/target/*-runner /tmp/certeasy-build/
 chmod +x /tmp/certeasy-build/*-runner
 cd /tmp/certeasy-build
 docker build -t certeasy:local .

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
@@ -1,6 +1,7 @@
 package org.certeasy.backend.certs;
 
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.certeasy.Certificate;
 import org.certeasy.KeyStrength;
 import org.certeasy.backend.common.BaseResource;

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/cert/NotFoundProblem.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/cert/NotFoundProblem.java
@@ -1,8 +1,10 @@
 package org.certeasy.backend.common.cert;
 
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.certeasy.backend.common.problem.Problem;
 
+@RegisterForReflection
 public class NotFoundProblem extends Problem {
 
     public NotFoundProblem(String type, String title, String detail) {

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/json/JacksonObjectMapperCustomizer.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/json/JacksonObjectMapperCustomizer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.quarkus.jackson.ObjectMapperCustomizer;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.certeasy.Certificate;
 import org.certeasy.backend.common.cert.CertificateInfo;
 import org.certeasy.backend.common.cert.CreatedCertInfo;

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/BadRequestProblem.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/BadRequestProblem.java
@@ -1,8 +1,10 @@
 package org.certeasy.backend.common.problem;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @JsonPropertyOrder({ "type", "title", "status", "detail", "violations" })
+@RegisterForReflection
 public class BadRequestProblem extends Problem {
 
 

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/ConstraintViolationProblem.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/ConstraintViolationProblem.java
@@ -1,6 +1,7 @@
 package org.certeasy.backend.common.problem;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.certeasy.backend.common.validation.Violation;
 
 import java.util.Collections;
@@ -8,6 +9,7 @@ import java.util.Set;
 
 
 @JsonPropertyOrder({ "type", "title", "status", "detail", "violations" })
+@RegisterForReflection
 public class ConstraintViolationProblem extends Problem {
 
     private Set<Violation> violations;

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/Problem.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/Problem.java
@@ -2,8 +2,10 @@ package org.certeasy.backend.common.problem;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @JsonPropertyOrder({ "type", "title", "status", "detail" })
+@RegisterForReflection
 public class Problem {
 
     @JsonProperty("type")

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/ServerErrorProblem.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/ServerErrorProblem.java
@@ -1,5 +1,8 @@
 package org.certeasy.backend.common.problem;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class ServerErrorProblem extends Problem {
 
     public ServerErrorProblem(String detail){

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/validation/Violation.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/validation/Violation.java
@@ -3,8 +3,10 @@ package org.certeasy.backend.common.validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @JsonPropertyOrder({"field", "type", "subType", "message"})
+@RegisterForReflection
 public record  Violation (String field, String type, @JsonProperty("sub_type") String subType, String message){
 
     public Violation(String field, String type, String subType,  String message){

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuersResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuersResource.java
@@ -1,5 +1,6 @@
 package org.certeasy.backend.issuer;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.certeasy.*;
 import org.certeasy.backend.common.BaseResource;
 import org.certeasy.backend.common.CertPEM;
@@ -80,26 +81,33 @@ public class IssuersResource extends BaseResource {
     @Path("/{issuerId}/cert-pem")
     public Response createFromPem(@PathParam("issuerId") String issuerId, CertPEM pem){
         return this.checkIssuerNotExistsThen(issuerId,  ()->{
+            LOGGER.info("Issuer name not taken: "+issuerId);
             Set<Violation> violationSet = pem.validate(ValidationPath.of("body"));
-            if(!violationSet.isEmpty())
+            if(!violationSet.isEmpty()) {
+                LOGGER.debug(String.format("%d constraint violations found", violationSet.size()));
                 return ProblemResponse.constraintViolations(violationSet);
+            }
             try{
                 Certificate certificate = context().pemCoder().decodeCertificate(pem.certFile(),
                         pem.keyFile());
                 BasicConstraints basicConstraints = certificate.getBasicConstraints();
-                if(basicConstraints==null || !basicConstraints.ca())
+                if(basicConstraints==null || !basicConstraints.ca()) {
+                    LOGGER.debug("Basic constraints extension missing on certificate");
                     return Response.status(422).entity(new ConstraintViolationProblem(
                             new Violation("body.pem.cert_file", ViolationType.STATE,
                                     "not_ca", "cert_file is does not have CA basic constraint"
                             ))).build();
+                }
                 registry().add(issuerId, certificate);
                 return Response.noContent().build();
             }catch (IllegalCertPemException ex) {
+                LOGGER.debug("Certificate not a valid PEM", ex);
                 return Response.status(422).entity(new ConstraintViolationProblem(
                         new Violation("body.pem.cert_file", ViolationType.FORMAT,
                                 "cert_file is NOT a valid PEM encoded certificate"
                         ))).build();
             }catch (IllegalPrivateKeyPemException ex){
+                LOGGER.debug("Key not a valid PEM", ex);
                 return Response.status(422).entity(new ConstraintViolationProblem(
                         new Violation("body.pem.key_file", ViolationType.FORMAT,
                                 "key_file is NOT a valid PEM encoded private key"


### PR DESCRIPTION
The native Image is not serializing error responses, that is why when an error occurs the server responds with `{}`. This change fixes the issue