### PR TITLE
feat: issuers hierarchy & filtering

### DIFF
--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
@@ -67,7 +67,7 @@ public class CertificatesResource extends BaseResource {
                     KeyStrength.valueOf(spec.getKeyStrength()),
                     spec.getValidity().toDateRange());
             Certificate certificate = issuer.issueCert(subAuthoritySpec);
-            return Response.ok(new IssuedCert(certificate.getSerial()))
+            return Response.ok(new CreatedSubCa(certificate.getDistinguishedName().digest(), certificate.getSerial()))
                     .build();
         });
     }

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CreatedSubCa.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CreatedSubCa.java
@@ -1,0 +1,5 @@
+package org.certeasy.backend.certs;
+
+public record CreatedSubCa(String id, String serial) {
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/BaseResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/BaseResource.java
@@ -41,21 +41,6 @@ public abstract class BaseResource {
         return this.context;
     }
 
-    public Response checkIssuerNotExistsThen(String issuerId, Supplier<Response> operation){
-        Optional<Response> optionalResponse = this.checkIssuerId(issuerId);
-        if(optionalResponse.isPresent())
-            return optionalResponse.get();
-        if(registry.exists(issuerId)){
-            LOGGER.warn("Issuer id taken: " +  issuerId);
-            return Response.status(409).entity(new Problem("/problems/issuerId/id-taken",
-                                    "Issuer ID Taken", 409,
-                                    "There is already an issuerId with the provided ID: " + issuerId))
-                    .type(MediaType.APPLICATION_JSON_TYPE)
-                    .build();
-        }
-        return operation.get();
-    }
-
     public Response checkIssuerExistsThen(String issuerId, IssuerOperation operation){
         Optional<Response> optionalResponse = this.checkIssuerId(issuerId);
         if(optionalResponse.isPresent())

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/CertEasyApplicationException.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/CertEasyApplicationException.java
@@ -1,0 +1,14 @@
+package org.certeasy.backend.common;
+
+import org.certeasy.CertEasyException;
+
+public class CertEasyApplicationException extends CertEasyException  {
+
+    public CertEasyApplicationException(String message) {
+        super(message);
+    }
+
+    public CertEasyApplicationException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/SubCaSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/SubCaSpec.java
@@ -1,5 +1,8 @@
 package org.certeasy.backend.common;
 
+import org.certeasy.DistinguishedName;
+import org.certeasy.RelativeDistinguishedName;
+import org.certeasy.SubjectAttributeType;
 import org.certeasy.backend.common.validation.ValidationPath;
 import org.certeasy.backend.common.validation.Violation;
 import org.certeasy.backend.common.validation.ViolationType;
@@ -16,6 +19,14 @@ public class SubCaSpec extends BaseCaCertSpec {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+
+    public DistinguishedName toDistinguishedName(){
+        return DistinguishedName.builder()
+                .append(new RelativeDistinguishedName(SubjectAttributeType.COMMON_NAME, getName()))
+                .append(getGeographicAddressInfo().toGeographicAddress().toRdns())
+                .build();
     }
 
     @Override

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/CertIssuer.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/CertIssuer.java
@@ -2,14 +2,13 @@ package org.certeasy.backend.issuer;
 
 import org.certeasy.*;
 import org.certeasy.backend.persistence.IssuerDatastore;
+import org.certeasy.backend.persistence.IssuerRegistry;
 import org.certeasy.backend.persistence.StoredCert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 
 /**
@@ -18,6 +17,8 @@ import java.util.stream.Collectors;
 public class CertIssuer {
 
     private String id;
+    private IssuerRegistry registry;
+
     private IssuerDatastore store;
     private Certificate certificate;
     private CertEasyContext context;
@@ -28,33 +29,34 @@ public class CertIssuer {
 
     private boolean disabled = false;
 
-    public CertIssuer(String id, IssuerDatastore store, CertEasyContext context){
-        if(id==null || id.isEmpty())
-            throw new IllegalArgumentException("id MUST not be null nor empty");
+    public CertIssuer(IssuerRegistry registry, IssuerDatastore store, CertEasyContext context){
+        if(registry==null)
+            throw new IllegalArgumentException("registry MUST not be null");
         if(store==null)
             throw new IllegalArgumentException("store MUST not be null");
         if(context==null)
             throw new IllegalArgumentException("context MUST not be null");
-        this.id = id;
+        this.registry = registry;
         this.store = store;
         this.context = context;
         this.readSerial();
     }
 
-    public CertIssuer(String id, IssuerDatastore store, CertEasyContext context, Certificate certificate){
-        if(id ==null || id.isEmpty())
-            throw new IllegalArgumentException("id MUST not be null nor empty");
+    public CertIssuer(IssuerRegistry registry, IssuerDatastore store, CertEasyContext context, Certificate certificate){
+        if(registry==null)
+            throw new IllegalArgumentException("registry MUST not be null");
         if(store==null)
             throw new IllegalArgumentException("store MUST not be null");
         if(context==null)
             throw new IllegalArgumentException("context MUST not be null");
         if(certificate==null)
             throw new IllegalArgumentException("certificate MUST not be null");
-        this.id = id;
+        this.registry = registry;
         this.store = store;
         this.context = context;
         this.certificate = certificate;
         this.setCertificate(certificate);
+        this.figureIdentity();
 
     }
 
@@ -67,6 +69,11 @@ public class CertIssuer {
         this.certificate = certificate;
         this.serial = certificate.getSerial();
         this.writeSerial();
+    }
+
+    private void figureIdentity(){
+        this.id = certificate.
+                getDistinguishedName().digest();
     }
 
     public boolean isDisabled() {
@@ -93,7 +100,10 @@ public class CertIssuer {
         if(certificate!=null)
             return;
         Optional<StoredCert> storedCert = store.getCert(serial);
-        storedCert.ifPresent(cert -> this.certificate = cert.getCertificate());
+        storedCert.ifPresent(cert -> {
+            this.certificate = cert.getCertificate();
+            this.figureIdentity();
+        });
     }
 
     private void writeSerial(){
@@ -125,6 +135,10 @@ public class CertIssuer {
         Certificate issuedCert = context.generator().generate(spec, certificate);
         LOGGER.info("Issued certificate with serial: {}", issuedCert.getSerial());
         this.store.put(issuedCert);
+        if(spec.getBasicConstraints().ca()) {
+            LOGGER.info("Creating issuer for issued certificate: "+certificate.getSerial());
+            this.registry.add(issuedCert);
+        }
         return issuedCert;
     }
 

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/CertIssuer.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/CertIssuer.java
@@ -7,8 +7,7 @@ import org.certeasy.backend.persistence.StoredCert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Optional;
+import java.util.*;
 
 
 /**
@@ -22,6 +21,7 @@ public class CertIssuer {
     private IssuerDatastore store;
     private Certificate certificate;
     private CertEasyContext context;
+
     private static final Logger LOGGER
             = LoggerFactory.getLogger(CertIssuer.class);
 

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/CreatedIssuerInfo.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/CreatedIssuerInfo.java
@@ -1,0 +1,7 @@
+package org.certeasy.backend.issuer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreatedIssuerInfo(@JsonProperty("issuer_id")  String issuerId) {
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfo.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfo.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
-@JsonPropertyOrder({"id", "type", "serial", "dn", "path_length"})
+@JsonPropertyOrder({"id", "name", "type", "serial", "dn", "path_length", "parent_id", "children_count"})
 public record IssuerInfo(
                          @JsonProperty("id")
                          String id,
+
+                         @JsonProperty("name")
+                         String name,
 
                          @JsonProperty("serial")
                          String serial,
@@ -19,5 +22,11 @@ public record IssuerInfo(
                          String distinguishedName,
 
                          @JsonProperty("path_length")
-                         int pathLength) {
+                         int pathLength,
+
+                         @JsonProperty("parent_id")
+                         String parentId,
+
+                         @JsonProperty("children_count")
+                         int totalChildren) {
 }

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfo.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfo.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
-@JsonPropertyOrder({"id", "name", "type", "serial", "dn", "path_length", "parent_id", "children_count"})
+@JsonPropertyOrder({"id", "name", "type", "serial", "dn", "path_length", "parent", "children_count"})
 public record IssuerInfo(
                          @JsonProperty("id")
                          String id,
@@ -24,8 +24,8 @@ public record IssuerInfo(
                          @JsonProperty("path_length")
                          int pathLength,
 
-                         @JsonProperty("parent_id")
-                         String parentId,
+                         @JsonProperty("parent")
+                         IssuerParent parent,
 
                          @JsonProperty("children_count")
                          int totalChildren) {

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfoFactory.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfoFactory.java
@@ -24,13 +24,13 @@ public final class IssuerInfoFactory {
         String distinguishedName = certificate.getDistinguishedName().toString();
 
         DistinguishedName issuerName = certificate.getIssuerName();
-        String parentId = null;
+        IssuerParent parent = null;
         if(!issuerName.equals(certificate.getDistinguishedName()))
-            parentId = issuerName.digest();
+            parent = new IssuerParent(issuerName.digest(), issuerName.getCommonName());
         int totalChildren  = registry.countChildrenOf(issuer);
         return new IssuerInfo(id, certificate.getDistinguishedName().getCommonName(),  serial, issuerType,
                 distinguishedName, certificate.getBasicConstraints()
-                .pathLength(), parentId, totalChildren);
+                .pathLength(), parent, totalChildren);
 
     }
 

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfoFactory.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfoFactory.java
@@ -1,0 +1,37 @@
+package org.certeasy.backend.issuer;
+
+import org.certeasy.CertEasyException;
+import org.certeasy.Certificate;
+import org.certeasy.DistinguishedName;
+import org.certeasy.backend.persistence.IssuerRegistry;
+
+import java.util.Optional;
+
+public final class IssuerInfoFactory {
+
+    private IssuerInfoFactory(){
+
+    }
+
+    public static IssuerInfo create(CertIssuer issuer, IssuerRegistry registry){
+        Optional<Certificate> optionalCertificate = issuer.getCertificate();
+        if(optionalCertificate.isEmpty())
+            throw new CertEasyException("issuer doesn't have a certificate");
+        Certificate certificate = optionalCertificate.get();
+        String id = issuer.getId();
+        String serial = certificate.getSerial();
+        IssuerType issuerType = certificate.isSelfSignedCA() ? IssuerType.ROOT : IssuerType.SUB_CA;
+        String distinguishedName = certificate.getDistinguishedName().toString();
+
+        DistinguishedName issuerName = certificate.getIssuerName();
+        String parentId = null;
+        if(!issuerName.equals(certificate.getDistinguishedName()))
+            parentId = issuerName.digest();
+        int totalChildren  = registry.countChildrenOf(issuer);
+        return new IssuerInfo(id, certificate.getDistinguishedName().getCommonName(),  serial, issuerType,
+                distinguishedName, certificate.getBasicConstraints()
+                .pathLength(), parentId, totalChildren);
+
+    }
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerParent.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerParent.java
@@ -1,0 +1,8 @@
+package org.certeasy.backend.issuer;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"id", "name"})
+public record IssuerParent(String id, String name) {
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuersResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuersResource.java
@@ -1,6 +1,5 @@
 package org.certeasy.backend.issuer;
 
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.certeasy.*;
 import org.certeasy.backend.common.BaseResource;
 import org.certeasy.backend.common.CertPEM;
@@ -11,7 +10,7 @@ import org.certeasy.backend.common.problem.ServerErrorProblem;
 import org.certeasy.backend.common.validation.ValidationPath;
 import org.certeasy.backend.common.validation.Violation;
 import org.certeasy.backend.common.validation.ViolationType;
-import org.certeasy.backend.persistence.StoredCert;
+import org.certeasy.backend.persistence.IssuerDuplicationException;
 import org.certeasy.certspec.CertificateAuthoritySpec;
 import org.certeasy.certspec.CertificateAuthoritySubject;
 import org.jboss.logging.Logger;
@@ -20,7 +19,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,109 +56,68 @@ public class IssuersResource extends BaseResource {
     }
 
     @POST
-    @Path("/{issuerId}/cert-spec")
-    public Response createFromSpec(@PathParam("issuerId") String issuerId, SubCaSpec spec){
-        return this.checkIssuerNotExistsThen(issuerId, () -> {
-            Set<Violation> violationSet = spec.validate(ValidationPath.of("body"));
-            if(!violationSet.isEmpty())
-                return ProblemResponse.constraintViolations(violationSet);
-            CertificateAuthoritySubject subject = new CertificateAuthoritySubject(
-                    spec.getName(),
-                    spec.getGeographicAddressInfo().
-                            toGeographicAddress());
-            CertificateAuthoritySpec authoritySpec = new CertificateAuthoritySpec(subject, spec.getPathLength(),
-                    KeyStrength.valueOf(spec.getKeyStrength()),
-                    spec.getValidity().toDateRange());
-            Certificate certificate = context().generator().generate(authoritySpec);
-            registry().add(issuerId, certificate);
-            return Response.noContent().build();
-        });
+    @Path("/cert-spec")
+    public Response createFromSpec(SubCaSpec spec){
+        Set<Violation> violationSet = spec.validate(ValidationPath.of("body"));
+        if(!violationSet.isEmpty())
+            return ProblemResponse.constraintViolations(violationSet);
+        CertificateAuthoritySubject subject = new CertificateAuthoritySubject(
+                spec.getName(),
+                spec.getGeographicAddressInfo().
+                        toGeographicAddress());
+        CertificateAuthoritySpec authoritySpec = new CertificateAuthoritySpec(subject, spec.getPathLength(),
+                KeyStrength.valueOf(spec.getKeyStrength()),
+                spec.getValidity().toDateRange());
+        Certificate certificate = context().generator().generate(authoritySpec);
+        try {
+            CertIssuer certIssuer = registry().add(certificate);
+            return Response.ok(new CreatedIssuerInfo(certIssuer.getId())).build();
+        }catch (IssuerDuplicationException ex){
+            return Response.status(409).entity(ex.asProblem()).build();
+        }
     }
 
     @POST
-    @Path("/{issuerId}/cert-pem")
-    public Response createFromPem(@PathParam("issuerId") String issuerId, CertPEM pem){
-        return this.checkIssuerNotExistsThen(issuerId,  ()->{
-            LOGGER.info("Issuer name not taken: "+issuerId);
-            Set<Violation> violationSet = pem.validate(ValidationPath.of("body"));
-            if(!violationSet.isEmpty()) {
-                LOGGER.debug(String.format("%d constraint violations found", violationSet.size()));
-                return ProblemResponse.constraintViolations(violationSet);
-            }
-            try{
-                Certificate certificate = context().pemCoder().decodeCertificate(pem.certFile(),
-                        pem.keyFile());
-                BasicConstraints basicConstraints = certificate.getBasicConstraints();
-                if(basicConstraints==null || !basicConstraints.ca()) {
-                    LOGGER.debug("Basic constraints extension missing on certificate");
-                    return Response.status(422).entity(new ConstraintViolationProblem(
-                            new Violation("body.pem.cert_file", ViolationType.STATE,
-                                    "not_ca", "cert_file is does not have CA basic constraint"
-                            ))).build();
-                }
-                registry().add(issuerId, certificate);
-                return Response.noContent().build();
-            }catch (IllegalCertPemException ex) {
-                LOGGER.debug("Certificate not a valid PEM", ex);
+    @Path("/cert-pem")
+    public Response createFromPem(CertPEM pem){
+        Set<Violation> violationSet = pem.validate(ValidationPath.of("body"));
+        if(!violationSet.isEmpty()) {
+            LOGGER.debug(String.format("%d constraint violations found", violationSet.size()));
+            return ProblemResponse.constraintViolations(violationSet);
+        }
+        try{
+            Certificate certificate = context().pemCoder().decodeCertificate(pem.certFile(),
+                    pem.keyFile());
+            BasicConstraints basicConstraints = certificate.getBasicConstraints();
+            if(basicConstraints==null || !basicConstraints.ca()) {
+                LOGGER.debug("Basic constraints extension missing on certificate");
                 return Response.status(422).entity(new ConstraintViolationProblem(
-                        new Violation("body.pem.cert_file", ViolationType.FORMAT,
-                                "cert_file is NOT a valid PEM encoded certificate"
+                        new Violation("body.pem.cert_file", ViolationType.STATE,
+                                "not_ca", "cert_file is does not have CA basic constraint"
                         ))).build();
-            }catch (IllegalPrivateKeyPemException ex){
-                LOGGER.debug("Key not a valid PEM", ex);
-                return Response.status(422).entity(new ConstraintViolationProblem(
-                        new Violation("body.pem.key_file", ViolationType.FORMAT,
-                                "key_file is NOT a valid PEM encoded private key"
-                        ))).build();
-            }catch (PEMCoderException ex){
-                String message = "Error decoding pem content";
-                LOGGER.error(message, ex);
-                return Response.status(500).entity(new ServerErrorProblem(message))
-                        .build();
             }
-        });
-    }
-
-    @POST
-    @Path("/{issuerId}/cert-ref")
-    public Response createFromRef(@PathParam("issuerId") String issuerId, IssuerCertRef ref) {
-        return this.checkIssuerNotExistsThen(issuerId, () -> {
-            Set<Violation> violationSet = ref.validate(ValidationPath.of("body"));
-            if (!violationSet.isEmpty())
-                return ProblemResponse.constraintViolations(violationSet);
-            Optional<CertIssuer> optionalCertIssuer = registry().getById(ref.issuerId());
-            //Issuer not found
-            if (optionalCertIssuer.isEmpty()) {
-                return ProblemResponse.constraintViolation(
-                        new Violation("body.issuer_id", ViolationType.STATE,
-                                "not-found",
-                                "No issuer found with a matching Id: " + ref.issuerId()
-                        ));
-            }
-            CertIssuer certIssuer = optionalCertIssuer.get();
-            Optional<StoredCert> optionalStoredCert = certIssuer.listCerts().stream()
-                    .filter(cert -> cert.getCertificate().getSerial().equals(ref.serial()))
-                    .findAny();
-            //Certificate not found
-            if (optionalStoredCert.isEmpty()) {
-                return ProblemResponse.constraintViolation(
-                        new Violation("body.serial", ViolationType.STATE,
-                                "not-found",
-                                "No certificate found with a matching serial: " + ref.serial()
-                        ));
-            }
-            Certificate certificate = optionalStoredCert.get().getCertificate();
-            //Certificate not a CA
-            if (!certificate.getBasicConstraints().ca()) {
-                return ProblemResponse.constraintViolation(
-                        new Violation("body.serial", ViolationType.STATE,
-                                "not-ca",
-                                "The referenced certificate is not a CA: " + ref.serial()
-                        ));
-            }
-            registry().add(issuerId, certificate);
-            return Response.noContent().build();
-        });
+            CertIssuer issuer = registry().add(certificate);
+            return Response.ok(new CreatedIssuerInfo(issuer.getId())).build();
+        }catch (IllegalCertPemException ex) {
+            LOGGER.debug("Certificate not a valid PEM", ex);
+            return Response.status(422).entity(new ConstraintViolationProblem(
+                    new Violation("body.pem.cert_file", ViolationType.FORMAT,
+                            "cert_file is NOT a valid PEM encoded certificate"
+                    ))).build();
+        }catch (IllegalPrivateKeyPemException ex){
+            LOGGER.debug("Key not a valid PEM", ex);
+            return Response.status(422).entity(new ConstraintViolationProblem(
+                    new Violation("body.pem.key_file", ViolationType.FORMAT,
+                            "key_file is NOT a valid PEM encoded private key"
+                    ))).build();
+        }catch (PEMCoderException ex){
+            String message = "Error decoding pem content";
+            LOGGER.error(message, ex);
+            return Response.status(500).entity(new ServerErrorProblem(message))
+                    .build();
+        }catch (IssuerDuplicationException ex){
+            return Response.status(409).entity(ex.asProblem()).build();
+        }
     }
 
 }

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/AbstractIssuerRegistry.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/AbstractIssuerRegistry.java
@@ -1,0 +1,85 @@
+package org.certeasy.backend.persistence;
+
+import org.certeasy.Certificate;
+import org.certeasy.backend.issuer.CertIssuer;
+import org.jboss.logging.Logger;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public abstract class AbstractIssuerRegistry implements IssuerRegistry {
+
+    private final Map<String, Set<CertIssuer>> childrenMap = new HashMap<>();
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractIssuerRegistry.class);
+
+
+    protected void discoverHierarchy(){
+
+        Collection<CertIssuer> certIssuers = this.list();
+        Collection<Certificate> certificates = certIssuers.stream()
+                .filter(CertIssuer::hasCertificate)
+                .map(CertIssuer::getCertificate)
+                .filter(Optional::isPresent)
+                .map(Optional::get).collect(Collectors.toSet());
+
+        certificates.forEach(cert -> this.childrenMap.put(cert.getIssuerName().digest(),
+                    new HashSet<>()));
+
+        this.list().forEach(this::updateHierarchy);
+
+    }
+
+    protected void updateHierarchy(CertIssuer issuer){
+        Optional<Certificate> optionalCertificate = issuer.getCertificate();
+        if(optionalCertificate.isEmpty())
+            return;
+        Certificate certificate = optionalCertificate.get();
+        if(certificate.isCA() && !childrenMap.containsKey(issuer.getId()))
+            childrenMap.put(issuer.getId(), new HashSet<>());
+        if(!certificate.isSelfSignedCA()){
+            String parentId = certificate.getIssuerName().digest();
+            getChildrenSet(parentId).ifPresent(siblings -> {
+                LOGGER.debug(String.format("Mapping {%s} as parent of {%s}",
+                        certificate.getIssuerName(), certificate.getDistinguishedName()));
+                siblings.add(issuer);
+            });
+        }
+    }
+
+    protected Optional<Set<CertIssuer>> getChildrenSet(String issuerId){
+        if(issuerId==null)
+            throw new IllegalArgumentException("issuerId MUST not be null");
+        Set<CertIssuer> childrenSet = childrenMap.get(issuerId);
+        if(childrenSet==null)
+            return Optional.empty();
+        return Optional.of(childrenSet);
+    }
+
+    @Override
+    public Set<CertIssuer> getChildrenOf(CertIssuer issuer) throws IssuerRegistryException {
+        if(issuer==null)
+            throw new IllegalArgumentException("issuer MUST not be null");
+        Optional<Set<CertIssuer>> optionalChildren = getChildrenSet(issuer.getId());
+        Set<CertIssuer> childrenSet = optionalChildren.orElse(Collections.emptySet());
+        return Collections.unmodifiableSet(childrenSet);
+    }
+
+    @Override
+    public int countChildrenOf(CertIssuer issuer) throws IssuerRegistryException {
+        if(issuer==null)
+            throw new IllegalArgumentException("issuer MUST not be null");
+        Optional<Set<CertIssuer>> optionalChildren = getChildrenSet(issuer.getId());
+        return optionalChildren.map(Set::size).orElse(0);
+    }
+
+    public void delete(CertIssuer issuer) throws IssuerRegistryException {
+        if(issuer==null)
+            throw new IllegalArgumentException("issuerId MUST not be null");
+        Optional<Certificate> optionalCert = issuer.getCertificate();
+        optionalCert.flatMap(cert -> getChildrenSet(cert.getIssuerName().digest()))
+                .ifPresent(set -> set.remove(issuer));
+    }
+
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/AbstractIssuerRegistry.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/AbstractIssuerRegistry.java
@@ -40,8 +40,8 @@ public abstract class AbstractIssuerRegistry implements IssuerRegistry {
         if(!certificate.isSelfSignedCA()){
             String parentId = certificate.getIssuerName().digest();
             getChildrenSet(parentId).ifPresent(siblings -> {
-                LOGGER.debug(String.format("Mapping {%s} as parent of {%s}",
-                        certificate.getIssuerName(), certificate.getDistinguishedName()));
+                LOGGER.debug(String.format("Mapping %s as parent of %s",
+                        certificate.getIssuerName().getCommonName(), certificate.getDistinguishedName().getCommonName()));
                 siblings.add(issuer);
             });
         }

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/IssuerDuplicationException.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/IssuerDuplicationException.java
@@ -1,0 +1,24 @@
+package org.certeasy.backend.persistence;
+
+import org.certeasy.DistinguishedName;
+import org.certeasy.backend.common.problem.Problem;
+
+public class IssuerDuplicationException extends IssuerRegistryException {
+
+    private final DistinguishedName distinguishedName;
+
+    public IssuerDuplicationException(DistinguishedName distinguishedName) {
+        super("There is already an issuer with the provided Distinguished Name: "+ distinguishedName);
+        this.distinguishedName = distinguishedName;
+    }
+
+    public DistinguishedName getDistinguishedName() {
+        return distinguishedName;
+    }
+
+    public Problem asProblem(){
+        return new Problem("/problems/issuer/duplication", "Issuer Duplication", 409,
+                "There is already an issuer with the provided Distinguished Name");
+    }
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/IssuerRegistry.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/IssuerRegistry.java
@@ -5,6 +5,7 @@ import org.certeasy.backend.issuer.CertIssuer;
 
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 public interface IssuerRegistry {
     Collection<CertIssuer> list() throws IssuerRegistryException;
@@ -12,4 +13,7 @@ public interface IssuerRegistry {
     boolean exists(String issuerId) throws IssuerRegistryException;
     Optional<CertIssuer> getById(String issuerId) throws IssuerRegistryException;
     void delete(CertIssuer issuer) throws IssuerRegistryException;
+    Set<CertIssuer> getChildrenOf(CertIssuer issuer) throws IssuerRegistryException;
+    int countChildrenOf(CertIssuer issuer) throws IssuerRegistryException;
+
 }

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/IssuerRegistry.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/IssuerRegistry.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface IssuerRegistry {
     Collection<CertIssuer> list() throws IssuerRegistryException;
-    CertIssuer add(String issuerId, Certificate certificate) throws IssuerRegistryException;
+    CertIssuer add(Certificate certificate) throws IssuerRegistryException;
     boolean exists(String issuerId) throws IssuerRegistryException;
     Optional<CertIssuer> getById(String issuerId) throws IssuerRegistryException;
     void delete(CertIssuer issuer) throws IssuerRegistryException;

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/directory/DirectoryIssuerRegistry.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/persistence/directory/DirectoryIssuerRegistry.java
@@ -16,11 +16,12 @@ import java.util.*;
 
 
 @ApplicationScoped
-public class DirectoryIssuerRegistry implements IssuerRegistry {
+public class DirectoryIssuerRegistry extends AbstractIssuerRegistry implements IssuerRegistry {
 
     private final File dataDirectory;
     private final CertEasyContext context;
     private final Map<String, CertIssuer> cache = new HashMap<>();
+
     private boolean scanned = false;
     private static final Logger LOGGER = Logger.getLogger(DirectoryIssuerRegistry.class);
 
@@ -61,9 +62,13 @@ public class DirectoryIssuerRegistry implements IssuerRegistry {
             }
             LOGGER.info("Found issuerId: " + issuerDirectory.getName());
             cache.put(issuerDirectory.getName(), issuer);
+            this.updateHierarchy(issuer);
         }
         this.scanned = true;
+        this.discoverHierarchy();
     }
+
+
 
     @Override
     public CertIssuer add(Certificate certificate) throws IssuerRegistryException {
@@ -84,6 +89,7 @@ public class DirectoryIssuerRegistry implements IssuerRegistry {
         IssuerDatastore datastore = new DirectoryIssuerDatastore(issuerDirectory, context);
         CertIssuer issuer = new CertIssuer(this, datastore, context, certificate);
         cache.put(issuerId, issuer);
+        this.updateHierarchy(issuer);
         LOGGER.info("Issuer added successfully: " + issuerId);
         return issuer;
     }
@@ -111,6 +117,8 @@ public class DirectoryIssuerRegistry implements IssuerRegistry {
         if(!issuer.isDisabled())
             issuer.disable();
         this.cache.remove(issuer.getId());
+        super.delete(issuer);
     }
+
 
 }

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -263,7 +263,7 @@ paths:
 
       responses:
         200:
-          $ref: '#/components/responses/SuccessfullyIssuedCert'
+          $ref: '#/components/responses/SuccessfullyCreatedSubCa'
         400:
           $ref: '#/components/responses/BadRequest'
         422:
@@ -991,7 +991,7 @@ components:
         - serial
 
 
-    SubCaCreated:
+    CreatedSubCa:
       type: object
       description: Represents a created sub-ca
       properties:
@@ -1263,6 +1263,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/IssuedCert'
+
+    SuccessfullyCreatedSubCa:
+      description: Certificate issued successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatedSubCa'
 
 
     ServerError:  # Can be referenced as '#/components/responses/ServerError'

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -68,15 +68,13 @@ paths:
         500:
           $ref: "#/components/responses/ServerError"
 
-  /issuers/{issuerId}/cert-spec:
+  /issuers/cert-spec:
     post:
       summary: Create Issuer from spec
       operationId: createIssuerFromSpec
       description: Create a new Issuer from a specification.
       tags:
         - Issuers
-      parameters:
-        - $ref: "#/components/parameters/IssuerId"
       requestBody:
         description: Issuer creation body
         content:
@@ -84,26 +82,24 @@ paths:
             schema:
               $ref: "#/components/schemas/IssuerCertSpec"
       responses:
-        204:
-          description: Issuer created successfully
+        200:
+          $ref: '#/components/responses/IssuerCreatedSuccessfully'
         400:
           $ref: '#/components/responses/BadRequest'
         422:
           $ref: '#/components/responses/IssuerSpecConstraintViolation'
         409:
-          $ref: '#/components/responses/IssuerIDTaken'
+          $ref: '#/components/responses/IssuerDuplication'
         500:
           $ref: "#/components/responses/ServerError"
 
-  /issuers/{issuerId}/cert-pem:
+  /issuers/cert-pem:
     post:
       summary: Create Issuer from PEM
       operationId: createIssuerFromPem
       description: Create a new Issuer from a PEM bundle.
       tags:
         - Issuers
-      parameters:
-        - $ref: "#/components/parameters/IssuerId"
       requestBody:
         description: Issuer creation body
         content:
@@ -111,44 +107,16 @@ paths:
             schema:
               $ref: "#/components/schemas/CertPem"
       responses:
-        204:
-          description: Issuer created successfully
+        200:
+          $ref: '#/components/responses/IssuerCreatedSuccessfully'
         400:
           $ref: '#/components/responses/BadRequest'
         422:
           $ref: '#/components/responses/IssuerPemConstraintViolation'
         409:
-          $ref: '#/components/responses/IssuerIDTaken'
+          $ref: '#/components/responses/IssuerDuplication'
         500:
           $ref: "#/components/responses/ServerError"
-
-  /issuers/{issuerId}/cert-ref:
-    post:
-      summary: Create Issuer from issued certificate
-      operationId: createIssuerFromRef
-      description: Create a new Issuer from a Sub-CA certificate issued by an existing issuerId.
-      tags:
-        - Issuers
-      parameters:
-        - $ref: "#/components/parameters/IssuerId"
-      requestBody:
-        description: Issuer creation body
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/IssuerCertRef"
-      responses:
-        204:
-          description: Issuer created successfully
-        400:
-          $ref: '#/components/responses/BadRequest'
-        422:
-          $ref: '#/components/responses/IssuerCertRefConstraintViolation'
-        409:
-          $ref: '#/components/responses/IssuerIDTaken'
-        500:
-          $ref: "#/components/responses/ServerError"
-
 
   /issuers/{issuerId}/certificates/tls-server:
     post:
@@ -273,7 +241,7 @@ paths:
       summary: Issue Sub Certificate-Authority Certificate
       operationId: issueSubCACert
       description: |
-        Issues a Sub Certificate-Authority Certificate. An RSA Key-pair will be generated and used for the Certificate.
+        Issues a Sub Certificate-Authority Certificate and register as Issuer. An RSA Key-pair will be generated and used for the Certificate.
         The issued certificate will contain the following extensions:
 
           *Basic Constraint (Critical)*
@@ -509,6 +477,14 @@ paths:
 
 components:
   schemas:
+
+    CreatedIssuer:
+      type: object
+      description: Represents a successfully created issuer
+      properties:
+        issuer_id:
+          type: string
+          description: Unique ID of the issuer
 
     SubjectAlternativeName:
       type: object
@@ -1015,6 +991,23 @@ components:
         - serial
 
 
+    SubCaCreated:
+      type: object
+      description: Represents a created sub-ca
+      properties:
+        id:
+          type: string
+          description: The issuer ID
+          example: 448d28c6814b4d5d863cfc1a2fc8f355
+        serial:
+          type: string
+          description: The sub-ca certificate serial number
+          example: 448d28c6-814b-4d5d-863c-fc1a2fc8f355
+      required:
+        - id
+        - serial
+
+
 
     Problem:
       type: object
@@ -1122,8 +1115,8 @@ components:
       required: true
       description: The unique identifier of the certificate issuerId
       schema:
-        pattern: ^[a-z]+(-[a-z]+)*$
-        example: lorem-ipsum
+        example: f2a8d9e0c7b4193f5e0867dcb2f
+
 
   responses:
 
@@ -1305,6 +1298,23 @@ components:
               - field: path.name
                 message: Name must not have numeric characters
                 type: format
+    IssuerCreatedSuccessfully:
+      description: Issuer Created successfully
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatedIssuer'
+    IssuerDuplication:
+      description: Issuer Duplication
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          example:
+            type: /problems/issuer/duplication
+            title: Issuer Duplication
+            detail: There is already an issuer with the provided Distinguished Name
+            status: 409
     IssuerIDTaken:
       description: Issuer ID taken
       content:

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -34,6 +34,17 @@ paths:
       description: Get List of Issuers available
       tags:
         - Issuers
+      parameters:
+        - name: type
+          description: Filter the type of issuers to be listed
+          required: false
+          in: query
+          schema:
+            type: string
+            enum:
+              - ROOT
+              - SUB_CA
+
       responses:
         200:
           description: Issuers List retrieved successfully
@@ -44,6 +55,34 @@ paths:
                 items:
                   $ref: "#/components/schemas/IssuerInfo"
                 minItems: 0
+        500:
+          $ref: "#/components/responses/ServerError"
+
+  /issuers/{issuerId}/children:
+    get:
+      summary: List children Issuers
+      operationId: getIssuerChildren
+      description: Get List of issuers that are children of the referenced issuer
+      tags:
+        - Issuers
+      parameters:
+        - $ref: "#/components/parameters/IssuerId"
+      responses:
+        200:
+          description: Issuers List retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IssuerInfo"
+                minItems: 0
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/IssuerNotFound'
+        422:
+          $ref: '#/components/responses/ListIssuerConstraintViolation'
         500:
           $ref: "#/components/responses/ServerError"
 
@@ -678,8 +717,8 @@ components:
       properties:
         id:
           type: string
-          description: The unique identifier of the issuerId
-          example: myca
+          description: The unique identifier of the issuer
+          example: 5d03898a7577009e8ab06062e84d5da20f2e172f
         serial:
           type: string
           description: The unique serial number of the certificate
@@ -699,12 +738,23 @@ components:
           description: The maximum depth of CAs that may exist below this CA. This limit is enforced when issuing a sub-ca certificate.
           default: 0
           minimum: 0
+        parent_id:
+          type: string
+          description: The unique identifier of the parent issuer. Only present on issuers of SUB_CA type.
+          example: 7a0ebcf787242db56662ccd1824bf1c20adc3e31
+        children_count:
+          type: integer
+          description: Total count of children issuers
+          default: 0
+          minimum: 0
       required:
         - id
         - serial
         - type
         - dn
         - path_length
+        - parent_id
+        - children_count
 
     CertPem:
       type: object
@@ -1257,6 +1307,25 @@ components:
                     type: format
                     message: cert_file is not valid PEM encoded certificate
     
+    ListIssuerConstraintViolation:
+      description: Constraint violation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            invalid-body:
+              value:
+                type: /problems/constraint-violation
+                title: Constraint Violation
+                detail: The request contains one or more constraint violations
+                status: 422
+                violations:
+                  - field: query.type
+                    type: enum
+                    message: "type MUST be one of: [ROOT, SUB_CA]"
+
+
     SuccessfullyIssuedCert:
       description: Certificate issued successfully
       content:

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -1163,7 +1163,7 @@ components:
       name: issuerId
       in: path
       required: true
-      description: The unique identifier of the certificate issuerId
+      description: The unique identifier of the issuer
       schema:
         example: f2a8d9e0c7b4193f5e0867dcb2f
 

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/ProblemTemplate.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/ProblemTemplate.java
@@ -2,6 +2,7 @@ package org.certeasy.backend;
 
 public enum ProblemTemplate {
     CONSTRAINT_VIOLATION("/problems/constraint-violation", "Constraint Violation",422, "The request violates one or more constraints"),
+    DUPLICATE_ISSUER("/problems/issuer/duplication", "Issuer Duplication", 409),
     ISSUER_ID_TAKEN("/problems/issuerId/id-taken", "Issuer ID Taken", 409);
 
     private String title;

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/issuer/IssuersResourceTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/issuer/IssuersResourceTest.java
@@ -99,14 +99,14 @@ class IssuersResourceTest extends BaseRestTest {
     void listIssuers_must_return_existing_issuer(){
 
         Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("example", authorityCert);
+        CertIssuer issuer = registry.add(authorityCert);
 
         IssuerInfo[] certs = given().when().get()
                 .as(IssuerInfo[].class);
         assertEquals(1, certs.length);
 
         IssuerInfo issuerInfo = certs[0];
-        assertEquals("example", issuerInfo.id());
+        assertEquals(issuer.getId(), issuerInfo.id());
         assertEquals(authorityCert.getSerial(), issuerInfo.serial());
         assertEquals(10, issuerInfo.pathLength());
         assertEquals("CN=Root, C=ZA, ST=Nelspruit, L=Mpumalanga, STREET=Third Base Urban. Fashion. UG73", issuerInfo.distinguishedName());
@@ -142,10 +142,10 @@ class IssuersResourceTest extends BaseRestTest {
     void deleteIssuer_must_remove_existing_issuer(){
 
         Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("dummy", authorityCert);
+        CertIssuer certIssuer = registry.add(authorityCert);
         assertFalse(registry.list().isEmpty());
 
-        given().delete("/dummy")
+        given().delete("/"+certIssuer.getId())
                 .then()
                 .statusCode(204);
 
@@ -158,8 +158,6 @@ class IssuersResourceTest extends BaseRestTest {
     @DisplayName("createFromPem() must create issuer successfully")
     void createFromPem_must_create_issuer_successfully() throws IOException {
 
-        assertFalse(registry.exists("ipsum"));
-
         Path pemDirectory = Paths.get("src/test/resources/pem/ca");
         String certPem = Files.readString(pemDirectory.resolve("cert.pem"));
         String keyPem = Files.readString(pemDirectory.resolve("key.pem"));
@@ -168,11 +166,10 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(pem)
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
-                .statusCode(204);
-
-        assertTrue(registry.exists("ipsum"));
+                .statusCode(200)
+                .body("issuer_id", notNullValue());
 
     }
 
@@ -184,7 +181,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(new CertPEM("", ""))
                 .when()
-                    .post("/ipsum/cert-pem")
+                    .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body(containsString("cert_file must not be be null nor empty"))
@@ -193,7 +190,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(new CertPEM(null, ""))
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body(containsString("cert_file must not be be null nor empty"))
@@ -202,7 +199,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(new CertPEM("", null))
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body(containsString("cert_file must not be be null nor empty"))
@@ -211,7 +208,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(new CertPEM(null, null))
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body(containsString("cert_file must not be be null nor empty"))
@@ -232,7 +229,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(pem)
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -259,7 +256,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(pem)
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -286,7 +283,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(pem)
                 .when()
-                .post("/ipsum/cert-pem")
+                .post("/cert-pem")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -302,26 +299,31 @@ class IssuersResourceTest extends BaseRestTest {
 
     @Test
     @Tag("createFromPem")
-    @DisplayName("createFromPem() must fail when issuerId is taken")
-    void createFromPem_must_fail_when_issuer_id_is_taken() throws IOException {
-
-        Certificate certificate = context.generator().generate(certificateAuthoritySpec);
-        registry.add("microsoft", certificate);
+    @DisplayName("createFromPem() must fail on attempt to duplicate")
+    void createFromPem_must_fail_when_on_attempt_to_duplicate() throws IOException {
 
         Path pemDirectory = Paths.get("src/test/resources/pem/ca");
         String certPem = Files.readString(pemDirectory.resolve("cert.pem"));
         String keyPem = Files.readString(pemDirectory.resolve("key.pem"));
 
         CertPEM pem = new CertPEM(certPem, keyPem);
+
         given().contentType(ContentType.JSON)
                 .body(pem)
                 .when()
-                .post("/microsoft/cert-pem")
+                .post("/cert-pem")
+                .then()
+                .statusCode(200);
+
+        given().contentType(ContentType.JSON)
+                .body(pem)
+                .when()
+                .post("/cert-pem")
                 .then()
                 .statusCode(409)
-                .body("type", equalTo(ProblemTemplate.ISSUER_ID_TAKEN.getType()))
-                .body("title", equalTo(ProblemTemplate.ISSUER_ID_TAKEN.getTitle()))
-                .body("status", equalTo(ProblemTemplate.ISSUER_ID_TAKEN.getStatus()));
+                .body("type", equalTo(ProblemTemplate.DUPLICATE_ISSUER.getType()))
+                .body("title", equalTo(ProblemTemplate.DUPLICATE_ISSUER.getTitle()))
+                .body("status", equalTo(ProblemTemplate.DUPLICATE_ISSUER.getStatus()));
 
     }
 
@@ -337,46 +339,45 @@ class IssuersResourceTest extends BaseRestTest {
         spec.setGeographicAddressInfo(new GeographicAddressInfo("US", "California", "Cupertino", "One Apple Park Way, Cupertino, CA 95014"));
         spec.setValidity(new CertValidity("2023-01-01", "2099-12-31"));
 
-        assertFalse(registry.exists("apple-ca"));
+        String issuerIdentity = spec.toDistinguishedName().digest();
+        assertFalse(registry.exists(issuerIdentity));
 
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/apple/cert-spec")
+                .post("/cert-spec")
                 .then()
-                .statusCode(204)
+                .statusCode(200)
+                .body("issuer_id", equalTo(issuerIdentity))
                 .log().all();
 
-        assertTrue(registry.exists("apple"));
+        assertTrue(registry.exists(issuerIdentity));
 
     }
 
+
     @Test
-    @Tag("createFromSpec")
-    @DisplayName("createFromSpec() must fail whe issuer id is taken")
-    void createFromSpec_must_fail_when_issuer_id_is_taken() {
+    @Tag("createFromPem")
+    @DisplayName("createFromPem() must fail whe issuer is duplicate")
+    void createFromPem_must_fail_when_certificate_is_duplicate() throws IOException {
 
-        Certificate certificate = context.generator().generate(certificateAuthoritySpec);
-        registry.add("microsoft", certificate);
-        
-        SubCaSpec spec = new SubCaSpec();
-        spec.setName("Microsoft-CA");
-        spec.setKeyStrength(KeyStrength.HIGH.name());
-        spec.setPathLength(4);
-        spec.setGeographicAddressInfo(new GeographicAddressInfo("US", "California", "Cupertino", "One Apple Park Way, Cupertino, CA 95014"));
-        spec.setValidity(new CertValidity("2023-01-01", "2099-12-31"));
+        Path pemDirectory = Paths.get("src/test/resources/pem/ca");
+        String certPem = Files.readString(pemDirectory.resolve("cert.pem"));
+        String keyPem = Files.readString(pemDirectory.resolve("key.pem"));
+        Certificate certificate = context.pemCoder().decodeCertificate(certPem, keyPem);
+        registry.add(certificate);
 
-        assertFalse(registry.exists("apple-ca"));
-
+        CertPEM pem = new CertPEM(certPem, keyPem);
         given().contentType(ContentType.JSON)
-                .body(spec)
+                .body(pem)
                 .when()
-                .post("/microsoft/cert-spec")
+                .post("/cert-pem")
                 .then()
                 .statusCode(409)
-                .body("type", equalTo(ProblemTemplate.ISSUER_ID_TAKEN.getType()))
-                .body("title", equalTo(ProblemTemplate.ISSUER_ID_TAKEN.getTitle()))
-                .body("status", equalTo(ProblemTemplate.ISSUER_ID_TAKEN.getStatus()));
+                .body("type", equalTo("/problems/issuer/duplication"))
+                .body("title", equalTo("Issuer Duplication"))
+                .body("detail", equalTo("There is already an issuer with the provided Distinguished Name"));
+
     }
 
     @Test
@@ -394,7 +395,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/google/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -424,7 +425,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/google/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -453,7 +454,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/netflix/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -484,7 +485,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/netflix/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -513,7 +514,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/emptyname/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -530,7 +531,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/nameless/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -550,7 +551,7 @@ class IssuersResourceTest extends BaseRestTest {
         given().contentType(ContentType.JSON)
                 .body(spec)
                 .when()
-                .post("/nameless/cert-spec")
+                .post("/cert-spec")
                 .then()
                 .statusCode(422)
                 .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
@@ -563,247 +564,4 @@ class IssuersResourceTest extends BaseRestTest {
                 .body("violations[0].message", equalTo("name length should not exceed 128 characters"));
 
     }
-
-    @Test
-    @Tag("createFromSpec")
-    @DisplayName("createFromSpec() must fail when key_strength is invalid")
-    void createFromSpec_must_fail_when_key_strength_is_invalid() {
-
-        SubCaSpec spec = new SubCaSpec();
-        spec.setName("Vodacom");
-        spec.setKeyStrength("");
-        spec.setPathLength(-1);
-        spec.setValidity(new CertValidity("2020-01-01", "2099-12-31"));
-        spec.setGeographicAddressInfo(new GeographicAddressInfo("MZ", "Maputo", "Kapmfumo", "Av. 25 de Setembro. Rua dos Desportistas"));
-
-        given().contentType(ContentType.JSON)
-                .body(spec)
-                .when()
-                .post("/vodacom/cert-spec")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.key_strength"))
-                .body("violations[0].type", equalTo("enum"))
-                .body("violations[0].message", equalTo("key_strength should be one of [LOW, MEDIUM, HIGH, VERY_HIGH]"));
-
-        spec.setKeyStrength("IPSUM");
-        given().contentType(ContentType.JSON)
-                .body(spec)
-                .when()
-                .post("/vodacom/cert-spec")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.key_strength"))
-                .body("violations[0].type", equalTo("enum"))
-                .body("violations[0].message", equalTo("key_strength should be one of [LOW, MEDIUM, HIGH, VERY_HIGH]"));
-
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must create issuer successfully")
-    void createFromRef_must_create_issuer_successfully(){
-        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("amazon", authorityCert);
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef("amazon", authorityCert.getSerial()))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(204)
-                .log().all();
-
-        assertTrue(registry.exists("orange"));
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must fail when issuerId null or empty")
-    void createFromRef_must_fail_when_issuer_id_null(){
-        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("amazon", authorityCert);
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef("", authorityCert.getSerial()))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.issuer_id"))
-                .body("violations[0].type", equalTo("required"))
-                .body("violations[0].message", equalTo("issuer_id must not be be null nor empty"));
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef(null, authorityCert.getSerial()))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.issuer_id"))
-                .body("violations[0].type", equalTo("required"))
-                .body("violations[0].message", equalTo("issuer_id must not be be null nor empty"));
-
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must fail when serial null or empty")
-    void createFromRef_must_fail_when_serial_null(){
-        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("amazon", authorityCert);
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef("amazon", ""))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.serial"))
-                .body("violations[0].type", equalTo("required"))
-                .body("violations[0].message", equalTo("serial must not be be null nor empty"));
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef("amazon", null))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.serial"))
-                .body("violations[0].type", equalTo("required"))
-                .body("violations[0].message", equalTo("serial must not be be null nor empty"));
-
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must fail when certificate not found")
-    void createFromRef_must_fail_when_certificate_not_found(){
-        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("amazon", authorityCert);
-        IssuerCertRef certRef = new IssuerCertRef("amazon", "1689847141252");
-
-        given().contentType(ContentType.JSON)
-                .body(certRef)
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.serial"))
-                .body("violations[0].type", equalTo("state"))
-                .body("violations[0].message", equalTo("No certificate found with a matching serial: "+certRef.serial()));
-
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must fail when certificate issuer is empty")
-    void createFromRef_must_fail_when_cert_issuer_is_empty(){
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef("amazon", "1689614819994"))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.issuer_id"))
-                .body("violations[0].type", equalTo("state"))
-                .body("violations[0].message", equalTo("No issuer found with a matching Id: amazon"));
-
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must fail when certificate referenced is not ca")
-    void createFromRef_must_fail_when_cert_ref_is_not_ca(){
-
-        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("amazon", authorityCert);
-
-        Certificate certificate = context.generator().generate(personalCertificateSpec, authorityCert);
-        registry.add("amazon", certificate);
-
-        given().contentType(ContentType.JSON)
-                .body(new IssuerCertRef("amazon", certificate.getSerial()))
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.serial"))
-                .body("violations[0].type", equalTo("state"))
-                .body("violations[0].message", equalTo("The referenced certificate is not a CA: "+ certificate.getSerial()))
-                .log().all();
-
-    }
-
-    @Test
-    @Tag("createFromRef")
-    @DisplayName("createFromRef() must fail when body not found")
-    void createFromRef_must_fail_when_body_not_found(){
-        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
-        registry.add("amazon", authorityCert);
-        IssuerCertRef certRef = new IssuerCertRef("amazon", "");
-
-        given().contentType(ContentType.JSON)
-                .body(certRef)
-                .when()
-                .post("/orange/cert-ref")
-                .then()
-                .statusCode(422)
-                .body("type", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getType()))
-                .body("title", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getTitle()))
-                .body("detail", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getDetail()))
-                .body("status", equalTo(ProblemTemplate.CONSTRAINT_VIOLATION.getStatus()))
-                .body("violations", hasSize(1))
-                .body("violations[0].field", equalTo("body.serial"))
-                .body("violations[0].type", equalTo("required"))
-                .body("violations[0].message", equalTo("serial must not be be null nor empty"));
-
-    }
-
 }

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/persistence/DirectoryIssuerRegistryTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/persistence/DirectoryIssuerRegistryTest.java
@@ -77,9 +77,7 @@ public class DirectoryIssuerRegistryTest extends DirectoryBaseTest {
         Certificate certificate = context.generator().generate(certSpec);
         IssuerRegistry registry = createRegistry();
 
-        assertThrows(IllegalArgumentException.class, () -> registry.add("", certificate), "name MUST not be null nor empty");
-        assertThrows(IllegalArgumentException.class, () -> registry.add(null, certificate), "name MUST not be null nor empty");
-        assertThrows(IllegalArgumentException.class, () -> registry.add("example", null), "certificate MUST not be null");
+        assertThrows(IllegalArgumentException.class, () -> registry.add(null), "certificate MUST not be null");
 //        assertThrows(IllegalArgumentException.class, () -> registry.add("example", certificate),"dir MUST not be null and MUST point to an existing directory");
     }
 
@@ -87,11 +85,11 @@ public class DirectoryIssuerRegistryTest extends DirectoryBaseTest {
     @DisplayName("add() must store issuer and certificate in directory")
     void add_must_store_issuer_and_certificate_in_directory(){
 
-        Path issuerDirectory = DATA_DIRECTORY.resolve("example");
-        assertFalse(Files.exists(issuerDirectory));
         Certificate certificate = context.generator().generate(certSpec);
+        Path issuerDirectory = DATA_DIRECTORY.resolve(certificate.getDistinguishedName().digest());
+        assertFalse(Files.exists(issuerDirectory));
         IssuerRegistry registry = createRegistry();
-        registry.add("example", certificate);
+        registry.add(certificate);
         assertTrue(Files.exists(issuerDirectory));
         Path certDirectory = issuerDirectory.resolve(certificate.getSerial());
         assertTrue(Files.exists(certDirectory));

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/persistence/MapIssuerRegistry.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/persistence/MapIssuerRegistry.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 @Alternative
 @ApplicationScoped
-public class MapIssuerRegistry implements IssuerRegistry {
+public class MapIssuerRegistry extends AbstractIssuerRegistry implements IssuerRegistry {
 
     private Map<String, CertIssuer> issuerMap = new HashMap<>();
 
@@ -51,6 +51,7 @@ public class MapIssuerRegistry implements IssuerRegistry {
     @Override
     public void delete(CertIssuer issuer) throws IssuerRegistryException {
         this.issuerMap.remove(issuer.getId());
+        super.delete(issuer);
     }
 
     public void clear(){

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/persistence/MapIssuerRegistry.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/persistence/MapIssuerRegistry.java
@@ -30,9 +30,11 @@ public class MapIssuerRegistry implements IssuerRegistry {
     }
 
     @Override
-    public CertIssuer add(String issuerId, Certificate certificate) throws IssuerRegistryException {
-        CertIssuer issuer = new CertIssuer(issuerId, new MapIssuerDatastore(context), context, certificate);
-        this.issuerMap.put(issuerId, issuer);
+    public CertIssuer add(Certificate certificate) throws IssuerRegistryException {
+        CertIssuer issuer = new CertIssuer(this, new MapIssuerDatastore(context), context, certificate);
+        if(issuerMap.containsKey(issuer.getId()))
+            throw new IssuerDuplicationException(certificate.getDistinguishedName());
+        this.issuerMap.put(issuer.getId(), issuer);
         return issuer;
     }
 

--- a/certeasy-bouncycastle/.idea/compiler.xml
+++ b/certeasy-bouncycastle/.idea/compiler.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="certeasy-bouncycastle" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="easycert-bouncycastle" target="19" />
+    </bytecodeTargetLevel>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="certeasy-bouncycastle" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/certeasy-bouncycastle/src/main/java/org/certeasy/bouncycastle/CertificateDecoder.java
+++ b/certeasy-bouncycastle/src/main/java/org/certeasy/bouncycastle/CertificateDecoder.java
@@ -63,7 +63,7 @@ public class CertificateDecoder {
 
     DistinguishedName extractIssuer(){
         X500Name issuer = holder.getIssuer();
-        return DistinguishedName.builder().parse(issuer.toString())
+        return DistinguishedName.builder().parse(issuer.toString(), true)
                 .build();
     }
 
@@ -77,26 +77,20 @@ public class CertificateDecoder {
     }
 
     private SubjectAlternativeName toSubjectAltName(GeneralName sanName) {
-        switch (sanName.getTagNo()) {
-            case GeneralName.dNSName:
-                return new SubjectAlternativeName(SubjectAlternativeNameType.DNS,
-                        sanName.getName().toString());
-            case GeneralName.iPAddress:
-                return new SubjectAlternativeName(SubjectAlternativeNameType.IP_ADDRESS,
-                        sanName.getName().toString());
-            case GeneralName.directoryName:
-                return new SubjectAlternativeName(SubjectAlternativeNameType.DIRECTORY_NAME,
-                        sanName.getName().toString());
-            case GeneralName.uniformResourceIdentifier:
-                return new SubjectAlternativeName(SubjectAlternativeNameType.URI,
-                        sanName.getName().toString());
-            case GeneralName.rfc822Name:
-                return new SubjectAlternativeName(SubjectAlternativeNameType.EMAIL,
-                        sanName.getName().toString());
-            default:
-                return new SubjectAlternativeName(SubjectAlternativeNameType.OTHER_NAME,
-                        sanName.getName().toString());
-        }
+        return switch (sanName.getTagNo()) {
+            case GeneralName.dNSName -> new SubjectAlternativeName(SubjectAlternativeNameType.DNS,
+                    sanName.getName().toString());
+            case GeneralName.iPAddress -> new SubjectAlternativeName(SubjectAlternativeNameType.IP_ADDRESS,
+                    sanName.getName().toString());
+            case GeneralName.directoryName -> new SubjectAlternativeName(SubjectAlternativeNameType.DIRECTORY_NAME,
+                    sanName.getName().toString());
+            case GeneralName.uniformResourceIdentifier -> new SubjectAlternativeName(SubjectAlternativeNameType.URI,
+                    sanName.getName().toString());
+            case GeneralName.rfc822Name -> new SubjectAlternativeName(SubjectAlternativeNameType.EMAIL,
+                    sanName.getName().toString());
+            default -> new SubjectAlternativeName(SubjectAlternativeNameType.OTHER_NAME,
+                    sanName.getName().toString());
+        };
     }
 
 

--- a/certeasy-core/src/main/java/org/certeasy/DistinguishedName.java
+++ b/certeasy-core/src/main/java/org/certeasy/DistinguishedName.java
@@ -1,5 +1,7 @@
 package org.certeasy;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -102,7 +104,7 @@ public record DistinguishedName(Set<RelativeDistinguishedName> relativeDistingui
         }
 
 
-        public Builder parse(String distinguishedName){
+        public Builder parse(String distinguishedName, boolean ignoreUnknownAttributes){
             if(distinguishedName==null || distinguishedName.isEmpty())
                 throw new IllegalArgumentException("distinguishedName MUST not be null");
             String[] rdnArray = distinguishedName.split("(?<!\\\\),+");
@@ -115,10 +117,16 @@ public record DistinguishedName(Set<RelativeDistinguishedName> relativeDistingui
                     String attributeValue = attributeArray[1];
                     this.distinguishedNameSet.add(new RelativeDistinguishedName(attributeType, attributeValue));
                 }catch (IllegalArgumentException ex){
+                    if(ignoreUnknownAttributes)
+                        continue;
                     throw new IllegalSubjectAttributeTypeException(attributeArray[0]);
                 }
             }
             return this;
+        }
+
+        public Builder parse(String distinguishedName){
+            return this.parse(distinguishedName, false);
         }
 
         public Builder append(RelativeDistinguishedName rdn){
@@ -147,7 +155,20 @@ public record DistinguishedName(Set<RelativeDistinguishedName> relativeDistingui
                 throw new IllegalArgumentException("MUST have at least one RDN");
             return new DistinguishedName(distinguishedNameSet);
         }
+    }
 
+    public String digest() {
+        try {
+            byte[] data = toString().getBytes();
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] digest = md.digest(data);
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest)
+                sb.append(String.format("%02X", b));
+            return sb.toString().toLowerCase();
+        }catch (NoSuchAlgorithmException ex){
+            throw new CertEasyException("missing SHA-1 algorithm", ex);
+        }
     }
 
 }


### PR DESCRIPTION
Changes
- Issuer ID is auto-generated (ID is deterministic and based on Distinguished Name)
- New endpoint to list children of an issuer
- Ability to filter issuers by type when Listing
- When you issue a Sub-CA certificate, it is automatically added as issuer