### PR TITLE
feat: add personal and employee certs support

### DIFF
--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
@@ -90,7 +90,7 @@ public class CertificatesResource extends BaseResource {
                     .build();
         return this.checkIssuerExistsThen(issuerId, (issuer) -> {
             PersonalIdentitySubject subject = new PersonalIdentitySubject(
-                    new PersonName(spec.getFirstName(), spec.getSurname()),
+                    new PersonName(spec.getName(), spec.getSurname()),
                     spec.getGeographicAddressInfo().
                             toGeographicAddress(),
                     spec.getTelephone(),
@@ -119,7 +119,7 @@ public class CertificatesResource extends BaseResource {
                     organizationInfo.getDepartment(),
                     organizationInfo.getJobTitle());
             EmployeeIdentitySubject subject = new EmployeeIdentitySubject(
-                    new PersonName(spec.getFirstName(), spec.getSurname()),
+                    new PersonName(spec.getName(), spec.getSurname()),
                     spec.getGeographicAddressInfo().
                             toGeographicAddress(),
                     spec.getTelephone(),

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
@@ -17,10 +17,7 @@ import org.certeasy.backend.common.validation.ViolationType;
 import org.certeasy.backend.issuer.CertIssuer;
 import org.certeasy.backend.issuer.ReadOnlyCertificateException;
 import org.certeasy.backend.persistence.StoredCert;
-import org.certeasy.certspec.CertificateAuthoritySpec;
-import org.certeasy.certspec.CertificateAuthoritySubject;
-import org.certeasy.certspec.TLSServerCertificateSpec;
-import org.certeasy.certspec.TLSServerSubject;
+import org.certeasy.certspec.*;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -80,6 +77,30 @@ public class CertificatesResource extends BaseResource {
             return Response.ok(new IssuedCert(certificate.getSerial()))
                     .build();
 
+        });
+    }
+
+    @POST
+    @Path("/personal")
+    public Response issuePersonalCertificate(@PathParam("issuerId") String issuerId, PersonalCertSpec spec){
+        Set<Violation> violationSet = spec.validate(ValidationPath.of("body"));
+        if(!violationSet.isEmpty())
+            return Response.status(422).entity(new ConstraintViolationProblem(violationSet))
+                    .build();
+        return this.checkIssuerExistsThen(issuerId, (issuer) -> {
+            PersonalIdentitySubject subject = new PersonalIdentitySubject(
+                    new PersonName(spec.getFirstName(), spec.getSurname()),
+                    spec.getGeographicAddressInfo().
+                            toGeographicAddress(),
+                    spec.getTelephone(),
+                    spec.getEmailAddresses(),
+                    spec.getUsernames());
+            PersonalCertificateSpec personalCertificateSpec = new PersonalCertificateSpec(subject,
+                    KeyStrength.valueOf(spec.getKeyStrength()),
+                    spec.getValidity().toDateRange());
+            Certificate certificate = issuer.issueCert(personalCertificateSpec);
+            return Response.ok(new IssuedCert(certificate.getSerial()))
+                    .build();
         });
     }
 

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/CertificatesResource.java
@@ -69,6 +69,7 @@ public class CertificatesResource extends BaseResource {
                     .build();
         return this.checkIssuerExistsThen(issuerId, (issuer) -> {
             TLSServerSubject subject = new TLSServerSubject(
+                    spec.getName(),
                     spec.getDomains(),
                     spec.getGeographicAddressInfo().
                             toGeographicAddress(),

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/EmployeeCertSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/EmployeeCertSpec.java
@@ -5,25 +5,23 @@ import org.certeasy.backend.common.BaseCertSpec;
 import org.certeasy.backend.common.validation.ValidationPath;
 import org.certeasy.backend.common.validation.Validator;
 import org.certeasy.backend.common.validation.Violation;
-import org.certeasy.backend.common.validation.ViolationType;
 
 import java.util.Set;
 
 public class EmployeeCertSpec extends BaseCertSpec {
 
-    @JsonProperty("first_name")
-    private String firstName;
+    private String name;
     private String surname;
     private String telephone;
 
     private EmploymentInfo employment;
 
-    public String getFirstName() {
-        return firstName;
+    public String getName() {
+        return name;
     }
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getSurname() {
@@ -57,11 +55,11 @@ public class EmployeeCertSpec extends BaseCertSpec {
         validator.object("employment", employment)
                 .notNull()
                 .cascade();
-        validator.string("first_name", firstName)
+        validator.string("name", name)
                 .notNull()
                 .lengthGreaterThan(0)
                 .lengthLessThan(255);
-        validator.string("surname", firstName)
+        validator.string("surname", surname)
                 .notNull()
                 .lengthGreaterThan(0)
                 .lengthLessThan(255);

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/EmployeeCertSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/EmployeeCertSpec.java
@@ -1,0 +1,74 @@
+package org.certeasy.backend.certs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.certeasy.backend.common.BaseCertSpec;
+import org.certeasy.backend.common.validation.ValidationPath;
+import org.certeasy.backend.common.validation.Validator;
+import org.certeasy.backend.common.validation.Violation;
+import org.certeasy.backend.common.validation.ViolationType;
+
+import java.util.Set;
+
+public class EmployeeCertSpec extends BaseCertSpec {
+
+    @JsonProperty("first_name")
+    private String firstName;
+    private String surname;
+    private String telephone;
+
+    private EmploymentInfo employment;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getTelephone() {
+        return telephone;
+    }
+
+    public void setTelephone(String telephone) {
+        this.telephone = telephone;
+    }
+
+    public EmploymentInfo getEmployment() {
+        return employment;
+    }
+
+    public void setEmployment(EmploymentInfo employment) {
+        this.employment = employment;
+    }
+
+    @Override
+    public Set<Violation> validate(ValidationPath path) {
+        Set<Violation> violationSet = super.validate(path);
+        Validator validator = Validator.with(path, violationSet);
+        validator.object("employment", employment)
+                .notNull()
+                .cascade();
+        validator.string("first_name", firstName)
+                .notNull()
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("surname", firstName)
+                .notNull()
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("telephone", telephone)
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        return violationSet;
+    }
+
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/EmploymentInfo.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/EmploymentInfo.java
@@ -1,0 +1,84 @@
+package org.certeasy.backend.certs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.certeasy.backend.common.validation.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class EmploymentInfo implements Validable {
+
+    @JsonProperty("organization_name")
+    private String organizationName;
+
+    @JsonProperty("job_title")
+    private String jobTitle;
+
+    @JsonProperty("email_address")
+    private String emailAddress;
+
+    private String username;
+
+    private String department;
+
+    public String getOrganizationName() {
+        return organizationName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
+
+    public String getJobTitle() {
+        return jobTitle;
+    }
+
+    public void setJobTitle(String jobTitle) {
+        this.jobTitle = jobTitle;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public Set<Violation> validate(ValidationPath path) {
+        Set<Violation> violationSet = new HashSet<>();
+        Validator validator = Validator.with(path, violationSet);
+        validator.string("organization_name", organizationName)
+                .notNull()
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("job_title", jobTitle)
+                .notNull()
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("email_address", emailAddress)
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("username", username)
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        return violationSet;
+    }
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/PersonalCertSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/PersonalCertSpec.java
@@ -5,15 +5,12 @@ import org.certeasy.backend.common.BaseCertSpec;
 import org.certeasy.backend.common.validation.ValidationPath;
 import org.certeasy.backend.common.validation.Validator;
 import org.certeasy.backend.common.validation.Violation;
-import org.certeasy.backend.common.validation.ViolationType;
 
 import java.util.Set;
 
 public class PersonalCertSpec extends BaseCertSpec {
 
-
-    @JsonProperty("first_name")
-    private String firstName;
+    private String name;
     private String surname;
     private String telephone;
     @JsonProperty("email_addresses")
@@ -21,12 +18,12 @@ public class PersonalCertSpec extends BaseCertSpec {
 
     private Set<String> usernames;
 
-    public String getFirstName() {
-        return firstName;
+    public String getName() {
+        return name;
     }
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getSurname() {
@@ -66,7 +63,7 @@ public class PersonalCertSpec extends BaseCertSpec {
         Set<Violation> violationSet = super.validate(path);
 
         Validator validator = Validator.with(path, violationSet);
-        validator.string("first_name", firstName)
+        validator.string("name", name)
                 .notNull()
                 .lengthGreaterThan(0)
                 .lengthLessThan(255);

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/PersonalCertSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/PersonalCertSpec.java
@@ -1,0 +1,82 @@
+package org.certeasy.backend.certs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.certeasy.backend.common.BaseCertSpec;
+import org.certeasy.backend.common.validation.ValidationPath;
+import org.certeasy.backend.common.validation.Validator;
+import org.certeasy.backend.common.validation.Violation;
+import org.certeasy.backend.common.validation.ViolationType;
+
+import java.util.Set;
+
+public class PersonalCertSpec extends BaseCertSpec {
+
+
+    @JsonProperty("first_name")
+    private String firstName;
+    private String surname;
+    private String telephone;
+    @JsonProperty("email_addresses")
+    private Set<String> emailAddresses;
+
+    private Set<String> usernames;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getTelephone() {
+        return telephone;
+    }
+
+    public void setTelephone(String telephone) {
+        this.telephone = telephone;
+    }
+
+    public Set<String> getEmailAddresses() {
+        return emailAddresses;
+    }
+
+    public void setEmailAddresses(Set<String> emailAddresses) {
+        this.emailAddresses = emailAddresses;
+    }
+
+    public Set<String> getUsernames() {
+        return usernames;
+    }
+
+    public void setUsernames(Set<String> usernames) {
+        this.usernames = usernames;
+    }
+
+    @Override
+    public Set<Violation> validate(ValidationPath path) {
+        Set<Violation> violationSet = super.validate(path);
+
+        Validator validator = Validator.with(path, violationSet);
+        validator.string("first_name", firstName)
+                .notNull()
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("surname", surname)
+                .notNull()
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        validator.string("telephone", telephone)
+                .lengthGreaterThan(0)
+                .lengthLessThan(255);
+        return violationSet;
+    }
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/PersonalCertSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/PersonalCertSpec.java
@@ -1,0 +1,72 @@
+package org.certeasy.backend.certs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.certeasy.backend.common.BaseCertSpec;
+import org.certeasy.backend.common.validation.ValidationPath;
+import org.certeasy.backend.common.validation.Violation;
+import org.certeasy.backend.common.validation.ViolationType;
+
+import java.util.Set;
+
+public class PersonalCertSpec extends BaseCertSpec {
+
+
+    @JsonProperty("first_name")
+    private String firstName;
+    private String surname;
+    private String telephone;
+    @JsonProperty("email_addresses")
+    private Set<String> emailAddresses;
+
+    private Set<String> usernames;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getTelephone() {
+        return telephone;
+    }
+
+    public void setTelephone(String telephone) {
+        this.telephone = telephone;
+    }
+
+    public Set<String> getEmailAddresses() {
+        return emailAddresses;
+    }
+
+    public void setEmailAddresses(Set<String> emailAddresses) {
+        this.emailAddresses = emailAddresses;
+    }
+
+    public Set<String> getUsernames() {
+        return usernames;
+    }
+
+    public void setUsernames(Set<String> usernames) {
+        this.usernames = usernames;
+    }
+
+    @Override
+    public Set<Violation> validate(ValidationPath path) {
+        Set<Violation> violationSet = super.validate(path);
+        if(firstName==null || firstName.isEmpty())
+            violationSet.add(new Violation(path, "first_name", ViolationType.REQUIRED, "must specify the person's first_name"));
+        if(surname==null || surname.isEmpty())
+            violationSet.add(new Violation(path, "surname", ViolationType.REQUIRED, "must specify the person's surname"));
+        return violationSet;
+    }
+}

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/ServerSpec.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/certs/ServerSpec.java
@@ -9,9 +9,19 @@ import java.util.Set;
 
 public class ServerSpec extends BaseCertSpec {
 
+    private String name;
+
     private Set<String> domains;
 
     private String organization;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public Set<String> getDomains() {
         return domains;
@@ -32,6 +42,8 @@ public class ServerSpec extends BaseCertSpec {
     @Override
     public Set<Violation> validate(ValidationPath path) {
         Set<Violation> violationSet = super.validate(path);
+        if(name==null || name.isEmpty())
+            violationSet.add(new Violation(path, "name", ViolationType.REQUIRED, "must specify a name for the certificate"));
         if(domains==null || domains.isEmpty())
             violationSet.add(new Violation(path, "domains", ViolationType.REQUIRED, "must specify at least one domain"));
         if(organization !=null && ( organization.isBlank() || organization.trim().length() < 1) )

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/ConstraintViolationProblem.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/problem/ConstraintViolationProblem.java
@@ -14,6 +14,10 @@ public class ConstraintViolationProblem extends Problem {
 
     private Set<Violation> violations;
 
+    public ConstraintViolationProblem(){
+
+    }
+
     public ConstraintViolationProblem(Violation violation){
         this(Set.of(violation));
     }

--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/common/validation/Validator.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/common/validation/Validator.java
@@ -1,0 +1,102 @@
+package org.certeasy.backend.common.validation;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class Validator {
+
+    private ValidationPath path;
+    private Set<Violation> violations;
+
+    private Validator(ValidationPath path, Set<Violation> violations){
+        this.path = path;
+        this.violations = violations;
+    }
+
+    public static Validator with(ValidationPath path, Set<Violation> violations){
+        if(path==null)
+            throw new IllegalArgumentException("path MUST not be null");
+        if(violations==null)
+            throw new IllegalArgumentException("violations set MUST not be null");
+        return new Validator(path,violations);
+    }
+
+
+    public Set<Violation> getViolations(){
+        return this.violations;
+    }
+
+    public StringValidation string(String field, String value){
+        if(field==null || field.isEmpty())
+            throw new IllegalArgumentException("field name MUST not be null nor empty");
+        return new StringValidation(field, value);
+    }
+
+    public ObjectValidation object(String field, Object value){
+        if(field==null || field.isEmpty())
+            throw new IllegalArgumentException("field name MUST not be null nor empty");
+        return new ObjectValidation(field, value);
+    }
+
+    public final class StringValidation {
+
+        private final String fieldName;
+        private final String value;
+
+        private StringValidation(String fieldName, String value){
+            this.fieldName = fieldName;
+            this.value = value;
+        }
+
+        public StringValidation lengthGreaterThan(int threshold){
+            if(value != null && value.length() <= threshold )
+                Validator.this.violations.add(new Violation(path, fieldName, ViolationType.LENGTH, fieldName + " must have length greater than "+ threshold));
+            return this;
+        }
+
+        public StringValidation lengthLessThan(int threshold){
+            if(value != null && value.length() >= threshold )
+                Validator.this.violations.add(new Violation(path, fieldName, ViolationType.LENGTH, fieldName + " must have length less than "+ threshold));
+            return this;
+        }
+
+        public StringValidation notNull(){
+            if(value ==null )
+                Validator.this.violations.add(new Violation(path, fieldName, ViolationType.REQUIRED, "must specify value for "+fieldName));
+            return this;
+        }
+
+        public StringValidation matchPattern(Pattern pattern){
+            if(pattern != null && !pattern.matcher(value).matches())
+                Validator.this.violations.add(new Violation(path, fieldName, ViolationType.PATTERN, "must meet desired pattern: "+pattern));
+            return this;
+        }
+
+    }
+
+    public final class ObjectValidation {
+
+        private final String fieldName;
+        private final Object value;
+
+        private ObjectValidation(String fieldName, Object value){
+            this.fieldName = fieldName;
+            this.value = value;
+        }
+
+        public ObjectValidation notNull() {
+            if (value == null)
+                Validator.this.violations.add(new Violation(path, fieldName, ViolationType.REQUIRED, "must specify value for " + fieldName));
+            return this;
+        }
+
+        public ObjectValidation cascade() {
+            if(value != null && value instanceof Validable){
+                Validator.this.violations.addAll(((Validable) value).validate(path.append(fieldName)));
+            }
+            return this;
+        }
+
+    }
+
+}

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -977,24 +977,30 @@ components:
             - subject_distinguished_name
             - key_usage
 
+    PersonInfo:
+      properties:
+        name:
+          type: string
+          description: The person's given name
+          example: Yaka
+        surname:
+          type: string
+          description: The person's surname
+          example: Matavele
+        telephone:
+          type: string
+          description: The person's telephone number
+      required:
+        - name
+        - surname
 
     PersonalCertificateRequest:
       allOf:
         - $ref: "#/components/schemas/BaseCertificateRequestWithAddress"
+        - $ref: "#/components/schemas/PersonInfo"
         - type: object
           description: A Request to generate a certificate to identify an individual
           properties:
-            first_name:
-              type: string
-              description: The person's first name
-              example: Yaka
-            surname:
-              type: string
-              description: The person's surname
-              example: Matavele
-            telephone:
-              type: string
-              description: The person's telephone number
             email_addresses:
               type: array
               description: The email addresses of the person
@@ -1013,28 +1019,16 @@ components:
             - validity
             - key_strength
             - location
-            - first_name
+            - name
             - surname
 
 
     EmployeeCertificateRequest:
       allOf:
-        - $ref: "#/components/schemas/PersonalCertificateRequest"
+        - $ref: "#/components/schemas/PersonInfo"
         - type: object
           description: A Request to generate a certificate to identify an individual as an employee.
           properties:
-            first_name:
-              type: string
-              description: The person's first name
-              example: Yaka
-            surname:
-              type: string
-              description: The person's surname
-              example: Matavele
-            telephone:
-              type: string
-              description: The person's telephone number
-
             employment:
               type: object
               properties:
@@ -1050,16 +1044,16 @@ components:
                   description: The job title of the employee
                   maxLength: 255
                 email_address:
-                  type: array
+                  type: string
                   description: The corporate email address of the employee, assigned by the company.
                   maxLength: 255
                 username:
-                  type: array
+                  type: string
                   description: The username assigned to the employee by the company
                   maxLength: 255
-
               required:
                 - name
+                - surname
                 - job_title
 
     SubCACertificateRequest:

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -1015,7 +1015,6 @@ components:
             - location
             - first_name
             - surname
-            - telephone
 
 
     EmployeeCertificateRequest:
@@ -1024,18 +1023,40 @@ components:
         - type: object
           description: A Request to generate a certificate to identify an individual as an employee.
           properties:
-            company:
+            first_name:
+              type: string
+              description: The person's first name
+              example: Yaka
+            surname:
+              type: string
+              description: The person's surname
+              example: Matavele
+            telephone:
+              type: string
+              description: The person's telephone number
+
+            employment:
               type: object
               properties:
-                name:
+                organization_name:
                   type: string
-                  description: The name of the company to which the person is employed
+                  description: The name of the organization of employment
+                  maxLength: 255
                 department:
                   type: string
                   description: The name of the department to which the employee belongs
                 job_title:
                   type: string
                   description: The job title of the employee
+                  maxLength: 255
+                email_address:
+                  type: array
+                  description: The corporate email address of the employee, assigned by the company.
+                  maxLength: 255
+                username:
+                  type: array
+                  description: The username assigned to the employee by the company
+                  maxLength: 255
 
               required:
                 - name

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -1015,7 +1015,6 @@ components:
             - location
             - first_name
             - surname
-            - telephone
 
 
     EmployeeCertificateRequest:

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -1067,9 +1067,13 @@ components:
         - type: object
           description: A Request to generate a Certificate to identify a TLS Server
           properties:
+            name:
+              type: string
+              description: A name for the certificate. Value be set as common-name (CN) on resulting certificate.
+              example: my-server
             domains:
               type: array
-              description: The domains that are associated to the server. All listed domains will be added to the certificate as DNS Subject Alternative Names and The first domain in the array will be used as common-name.
+              description: The domains that are associated to the server. All listed domains will be added to the certificate as DNS Subject Alternative Names.
               items:
                 type: string
                 description: A domain name
@@ -1080,6 +1084,7 @@ components:
               description: The name of the organization that owns the server to be secured with TLS.
               example: Apple Inc
           required:
+            - name
             - domains
             - validity
             - key_strength

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
@@ -152,6 +152,61 @@ class CertificatesResourceTest extends BaseRestTest {
 
     }
 
+    @Test
+    void must_succeed_issuing_tls_cert_with_spec_without_organization(){
+
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        ServerSpec spec = new ServerSpec();
+        spec.setName("example.org");
+        spec.setDomains(Set.of("www.example.org", "example.org"));
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/tls-server", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .log().all();
+
+    }
+
+    @Test
+    void must_succeed_issuing_basic_personal_cert(){
+
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        PersonalCertSpec spec = new PersonalCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/personal", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .log().all();
+
+    }
 
     @Test
     void must_fail_to_issue_sub_ca_cert_for_unknown_issuer(){

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
@@ -192,7 +192,7 @@ class CertificatesResourceTest extends BaseRestTest {
         CertIssuer certIssuer = registry.add(authorityCert);
 
         PersonalCertSpec spec = new PersonalCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setKeyStrength(KeyStrength.HIGH.name());
         spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
@@ -226,7 +226,7 @@ class CertificatesResourceTest extends BaseRestTest {
         employmentInfo.setEmailAddress("john.doe@example.com");
 
         EmployeeCertSpec spec = new EmployeeCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmployment(employmentInfo);
         spec.setTelephone("+258841010800");
@@ -291,7 +291,7 @@ class CertificatesResourceTest extends BaseRestTest {
         employmentInfo.setEmailAddress("john.doe@example.com");
 
         EmployeeCertSpec spec = new EmployeeCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmployment(employmentInfo);
         spec.setTelephone("+258841010800");
@@ -352,7 +352,7 @@ class CertificatesResourceTest extends BaseRestTest {
         EmploymentInfo employmentInfo = new EmploymentInfo();
 
         EmployeeCertSpec spec = new EmployeeCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmployment(employmentInfo);
         spec.setTelephone("+258841010800");
@@ -393,7 +393,7 @@ class CertificatesResourceTest extends BaseRestTest {
         employmentInfo.setUsername("");
 
         EmployeeCertSpec spec = new EmployeeCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmployment(employmentInfo);
         spec.setTelephone("+258841010800");
@@ -437,7 +437,7 @@ class CertificatesResourceTest extends BaseRestTest {
         employmentInfo.setJobTitle("Chief Executive Dummy");
 
         EmployeeCertSpec spec = new EmployeeCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmployment(employmentInfo);
         spec.setTelephone("+258841010800");
@@ -487,7 +487,7 @@ class CertificatesResourceTest extends BaseRestTest {
         CertIssuer certIssuer = registry.add(authorityCert);
 
         PersonalCertSpec spec = new PersonalCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmailAddresses(Set.of("john.doe@gmail.com", "johndoe@example.com"));
         spec.setUsernames(Set.of("john.doe", "johndoe"));
@@ -545,7 +545,7 @@ class CertificatesResourceTest extends BaseRestTest {
         CertIssuer certIssuer = registry.add(authorityCert);
 
         PersonalCertSpec spec = new PersonalCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setEmailAddresses(Set.of("john.doe@gmail.com", "johndoe@example.com"));
         spec.setKeyStrength(KeyStrength.HIGH.name());
@@ -594,7 +594,7 @@ class CertificatesResourceTest extends BaseRestTest {
         CertIssuer certIssuer = registry.add(authorityCert);
 
         PersonalCertSpec spec = new PersonalCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setUsernames(Set.of("john.doe", "johndoe123"));
         spec.setKeyStrength(KeyStrength.HIGH.name());
@@ -643,7 +643,7 @@ class CertificatesResourceTest extends BaseRestTest {
         CertIssuer certIssuer = registry.add(authorityCert);
 
         PersonalCertSpec spec = new PersonalCertSpec();
-        spec.setFirstName("John");
+        spec.setName("John");
         spec.setSurname("Doe");
         spec.setTelephone("+258840101023");
         spec.setKeyStrength(KeyStrength.HIGH.name());

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
@@ -131,6 +131,7 @@ class CertificatesResourceTest extends BaseRestTest {
         CertIssuer certIssuer = registry.add(authorityCert);
 
         ServerSpec spec = new ServerSpec();
+        spec.setName("certeasy.org");
         spec.setDomains(Set.of("www.certeasy.org", "certeasy.org"));
         spec.setKeyStrength(KeyStrength.HIGH.name());
         spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
@@ -140,6 +141,34 @@ class CertificatesResourceTest extends BaseRestTest {
         spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
                 Month.DECEMBER, 31))));
         spec.setOrganization("Certeasy Inc");
+
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/tls-server", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .log().all();
+
+    }
+
+    @Test
+    void must_succeed_issuing_tls_cert_with_spec_without_organization(){
+
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        ServerSpec spec = new ServerSpec();
+        spec.setName("example.org");
+        spec.setDomains(Set.of("www.example.org", "example.org"));
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
 
 
         given().contentType(MediaType.APPLICATION_JSON)

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/CertificatesResourceTest.java
@@ -7,10 +7,13 @@ import org.certeasy.backend.BaseRestTest;
 import org.certeasy.backend.common.SubCaSpec;
 import org.certeasy.backend.common.cert.CertValidity;
 import org.certeasy.backend.common.cert.GeographicAddressInfo;
+import org.certeasy.backend.common.problem.ConstraintViolationProblem;
+import org.certeasy.backend.common.validation.Violation;
 import org.certeasy.backend.issuer.CertIssuer;
 import org.certeasy.backend.persistence.IssuerRegistry;
 import org.certeasy.backend.persistence.MapIssuerRegistry;
 import org.certeasy.backend.persistence.MemoryPersistenceProfile;
+import org.certeasy.backend.persistence.StoredCert;
 import org.certeasy.certspec.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +23,7 @@ import javax.ws.rs.core.MediaType;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -181,6 +185,503 @@ class CertificatesResourceTest extends BaseRestTest {
 
     }
 
+    @Test
+    void must_succeed_issuing_basic_personal_cert(){
+
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        PersonalCertSpec spec = new PersonalCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/personal", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .log().all();
+
+    }
+
+    @Test
+    void must_succeed_issuing_employee_cert_with_all_attributes(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        EmploymentInfo employmentInfo = new EmploymentInfo();
+        employmentInfo.setOrganizationName("Example Inc");
+        employmentInfo.setJobTitle("Chief Executive Dummy");
+        employmentInfo.setDepartment("Executive department");
+        employmentInfo.setUsername("john.doe");
+        employmentInfo.setEmailAddress("john.doe@example.com");
+
+        EmployeeCertSpec spec = new EmployeeCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmployment(employmentInfo);
+        spec.setTelephone("+258841010800");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/employee", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.EMPLOYEE, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals(employmentInfo.getJobTitle(), distinguishedName.findFirst(SubjectAttributeType.TITLE).orElseThrow().value());
+        assertEquals(employmentInfo.getDepartment(), distinguishedName.findFirst(SubjectAttributeType.ORGANIZATION_UNIT).orElseThrow().value());
+        assertEquals(employmentInfo.getOrganizationName(), distinguishedName.findFirst(SubjectAttributeType.ORGANIZATION_NAME).orElseThrow().value());
+        assertEquals(employmentInfo.getJobTitle(), distinguishedName.findFirst(SubjectAttributeType.TITLE).orElseThrow().value());
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+        assertEquals("+258841010800", distinguishedName.findFirst(SubjectAttributeType.TELEPHONE_NUMBER).orElseThrow().value());
+
+        Set<SubjectAlternativeName> sans = certificate.getSubjectAltNames();
+        assertEquals(2, sans.size());
+
+        Set<String> emails = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.EMAIL)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(emails.contains("john.doe@example.com"));
+
+        Set<String> usernames = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.OTHER_NAME)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(usernames.contains("john.doe"));
+    }
+
+    @Test
+    void must_succeed_issuing_employee_cert_without_department_attributes(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        EmploymentInfo employmentInfo = new EmploymentInfo();
+        employmentInfo.setOrganizationName("Example Inc");
+        employmentInfo.setJobTitle("Chief Executive Dummy");
+        employmentInfo.setUsername("john.doe");
+        employmentInfo.setEmailAddress("john.doe@example.com");
+
+        EmployeeCertSpec spec = new EmployeeCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmployment(employmentInfo);
+        spec.setTelephone("+258841010800");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/employee", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.EMPLOYEE, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals(employmentInfo.getJobTitle(), distinguishedName.findFirst(SubjectAttributeType.TITLE).orElseThrow().value());
+        assertTrue(distinguishedName.findFirst(SubjectAttributeType.ORGANIZATION_UNIT).isEmpty());
+        assertEquals(employmentInfo.getOrganizationName(), distinguishedName.findFirst(SubjectAttributeType.ORGANIZATION_NAME).orElseThrow().value());
+        assertEquals(employmentInfo.getJobTitle(), distinguishedName.findFirst(SubjectAttributeType.TITLE).orElseThrow().value());
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+        assertEquals("+258841010800", distinguishedName.findFirst(SubjectAttributeType.TELEPHONE_NUMBER).orElseThrow().value());
+
+        Set<SubjectAlternativeName> sans = certificate.getSubjectAltNames();
+        assertEquals(2, sans.size());
+
+        Set<String> emails = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.EMAIL)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(emails.contains("john.doe@example.com"));
+
+        Set<String> usernames = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.OTHER_NAME)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(usernames.contains("john.doe"));
+    }
+
+    @Test
+    void must_fail_issuing_employee_cert_with_null_employment_info(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        EmploymentInfo employmentInfo = new EmploymentInfo();
+
+        EmployeeCertSpec spec = new EmployeeCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmployment(employmentInfo);
+        spec.setTelephone("+258841010800");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        ConstraintViolationProblem problem = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/employee", certIssuer.getId()))
+                .then()
+                .statusCode(422)
+                .extract().body().as(ConstraintViolationProblem.class);
+
+
+        Set<Violation> violations = problem.getViolations();
+        assertEquals(2, violations.size());
+
+        Violation organizationNameViolation = violations.stream().filter(it -> it.field().equals("body.employment.organization_name")).findAny().orElseThrow();
+        assertEquals("must specify value for organization_name", organizationNameViolation.message());
+        Violation jobTitleViolation = violations.stream().filter(it -> it.field().equals("body.employment.job_title")).findAny().orElseThrow();
+        assertEquals("must specify value for job_title", jobTitleViolation.message());
+    }
+
+    @Test
+    void must_fail_issuing_employee_cert_with_empty_employment_info(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        EmploymentInfo employmentInfo = new EmploymentInfo();
+        employmentInfo.setOrganizationName("");
+        employmentInfo.setJobTitle("");
+        employmentInfo.setEmailAddress("");
+        employmentInfo.setUsername("");
+
+        EmployeeCertSpec spec = new EmployeeCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmployment(employmentInfo);
+        spec.setTelephone("+258841010800");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        ConstraintViolationProblem problem = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/employee", certIssuer.getId()))
+                .then()
+                .statusCode(422)
+                .extract().body().as(ConstraintViolationProblem.class);
+
+
+        Set<Violation> violations = problem.getViolations();
+        assertEquals(4, violations.size());
+
+        Violation organizationNameViolation = violations.stream().filter(it -> it.field().equals("body.employment.organization_name")).findAny().orElseThrow();
+        assertEquals("organization_name must have length greater than 0", organizationNameViolation.message());
+        Violation jobTitleViolation = violations.stream().filter(it -> it.field().equals("body.employment.job_title")).findAny().orElseThrow();
+        assertEquals("job_title must have length greater than 0", jobTitleViolation.message());
+        Violation emailAddresseViolation = violations.stream().filter(it -> it.field().equals("body.employment.email_address")).findAny().orElseThrow();
+        assertEquals("email_address must have length greater than 0", emailAddresseViolation.message());
+        Violation usernameViolation = violations.stream().filter(it -> it.field().equals("body.employment.username")).findAny().orElseThrow();
+        assertEquals("username must have length greater than 0", usernameViolation.message());
+
+    }
+
+    @Test
+    void must_succeed_issuing_employee_cert_without_email_and_usernames(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        EmploymentInfo employmentInfo = new EmploymentInfo();
+        employmentInfo.setOrganizationName("Example Inc");
+        employmentInfo.setJobTitle("Chief Executive Dummy");
+
+        EmployeeCertSpec spec = new EmployeeCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmployment(employmentInfo);
+        spec.setTelephone("+258841010800");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/employee", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.EMPLOYEE, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals(employmentInfo.getJobTitle(), distinguishedName.findFirst(SubjectAttributeType.TITLE).orElseThrow().value());
+        assertTrue(distinguishedName.findFirst(SubjectAttributeType.ORGANIZATION_UNIT).isEmpty());
+        assertEquals(employmentInfo.getOrganizationName(), distinguishedName.findFirst(SubjectAttributeType.ORGANIZATION_NAME).orElseThrow().value());
+        assertEquals(employmentInfo.getJobTitle(), distinguishedName.findFirst(SubjectAttributeType.TITLE).orElseThrow().value());
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+        assertEquals("+258841010800", distinguishedName.findFirst(SubjectAttributeType.TELEPHONE_NUMBER).orElseThrow().value());
+
+        Set<SubjectAlternativeName> sans = certificate.getSubjectAltNames();
+        assertEquals(0, sans.size());
+
+    }
+
+    @Test
+    void must_succeed_issuing_personal_cert_with_all_attributes(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        PersonalCertSpec spec = new PersonalCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmailAddresses(Set.of("john.doe@gmail.com", "johndoe@example.com"));
+        spec.setUsernames(Set.of("john.doe", "johndoe"));
+        spec.setTelephone("+258841010800");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/personal", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.PERSONAL, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+        assertEquals("+258841010800", distinguishedName.findFirst(SubjectAttributeType.TELEPHONE_NUMBER).orElseThrow().value());
+
+        Set<SubjectAlternativeName> sans = certificate.getSubjectAltNames();
+        assertEquals(4, sans.size());
+
+        Set<String> emails = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.EMAIL)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(emails.contains("john.doe@gmail.com"));
+        assertTrue(emails.contains("johndoe@example.com"));
+
+        Set<String> usernames = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.OTHER_NAME)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(usernames.contains("john.doe"));
+        assertTrue(usernames.contains("johndoe"));
+    }
+
+    @Test
+    void must_succeed_issuing_personal_cert_with_emails(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        PersonalCertSpec spec = new PersonalCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setEmailAddresses(Set.of("john.doe@gmail.com", "johndoe@example.com"));
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/personal", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.PERSONAL, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+
+        Set<SubjectAlternativeName> sans = certificate.getSubjectAltNames();
+        assertEquals(2, sans.size());
+
+        Set<String> usernames = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.EMAIL)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(usernames.contains("john.doe@gmail.com"));
+        assertTrue(usernames.contains("johndoe@example.com"));
+    }
+
+    @Test
+    void must_succeed_issuing_personal_cert_with_usernames(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        PersonalCertSpec spec = new PersonalCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setUsernames(Set.of("john.doe", "johndoe123"));
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/personal", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.PERSONAL, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+
+        Set<SubjectAlternativeName> sans = certificate.getSubjectAltNames();
+        assertEquals(2, sans.size());
+
+        Set<String> usernames = sans.stream().filter(it -> it.type() == SubjectAlternativeNameType.OTHER_NAME)
+                .map(SubjectAlternativeName::value)
+                .collect(Collectors.toSet());
+        assertTrue(usernames.contains("john.doe"));
+        assertTrue(usernames.contains("johndoe123"));
+    }
+
+    @Test
+    void must_succeed_issuing_personal_cert_with_telephone(){
+        Certificate authorityCert = context.generator().generate(certificateAuthoritySpec);
+        CertIssuer certIssuer = registry.add(authorityCert);
+
+        PersonalCertSpec spec = new PersonalCertSpec();
+        spec.setFirstName("John");
+        spec.setSurname("Doe");
+        spec.setTelephone("+258840101023");
+        spec.setKeyStrength(KeyStrength.HIGH.name());
+        spec.setGeographicAddressInfo(new GeographicAddressInfo("ZA",
+                "Nelspruit",
+                "Mpumalanga",
+                "Third Base Urban. Fashion. UG73"));
+        spec.setValidity(new CertValidity(new DateRange(LocalDate.of(3010,
+                Month.DECEMBER, 31))));
+
+        String serial = given().contentType(MediaType.APPLICATION_JSON)
+                .body(spec)
+                .post(String.format("/api/issuers/%s/certificates/personal", certIssuer.getId()))
+                .then()
+                .statusCode(200)
+                .body("serial", notNullValue())
+                .extract().body().path("serial");
+
+        StoredCert issuedCert = certIssuer.getIssuedCert(serial).orElseThrow();
+        assertEquals(IssuedCertType.PERSONAL, issuedCert.getCertType());
+        Certificate certificate = issuedCert.getCertificate();
+        DistinguishedName distinguishedName = certificate.getDistinguishedName();
+
+        String commonName = distinguishedName.getCommonName();
+        assertEquals("John Doe", commonName);
+        assertEquals("John", distinguishedName.findFirst(SubjectAttributeType.GIVEN_NAME).orElseThrow().value());
+        assertEquals("Doe", distinguishedName.findFirst(SubjectAttributeType.SURNAME).orElseThrow().value());
+        assertEquals("ZA", distinguishedName.findFirst(SubjectAttributeType.COUNTRY_NAME).orElseThrow().value());
+        assertEquals("Nelspruit", distinguishedName.findFirst(SubjectAttributeType.PROVINCE).orElseThrow().value());
+        assertEquals("Mpumalanga", distinguishedName.findFirst(SubjectAttributeType.LOCALITY).orElseThrow().value());
+        assertEquals("Third Base Urban. Fashion. UG73", distinguishedName.findFirst(SubjectAttributeType.STREET).orElseThrow().value());
+
+        assertTrue(distinguishedName.hasAttribute(SubjectAttributeType.TELEPHONE_NUMBER));
+        Set<RelativeDistinguishedName> telephones = distinguishedName.findAll(SubjectAttributeType.TELEPHONE_NUMBER);
+        assertEquals(1, telephones.size());
+        assertEquals("+258840101023", telephones.iterator().next().value());
+
+    }
 
     @Test
     void must_fail_to_issue_sub_ca_cert_for_unknown_issuer(){

--- a/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/IssuedCertTypeTest.java
+++ b/certeasy-backend-app/src/test/java/org/certeasy/backend/certs/IssuedCertTypeTest.java
@@ -62,6 +62,7 @@ public class IssuedCertTypeTest {
     void certificate_must_be_matched_as_tls_server(){
 
         TLSServerSubject tlsServerSubject = new TLSServerSubject(
+                "example.com",
                 Set.of("example.com", "www.example.com"), address, "Example Inc"
         );
 

--- a/certeasy-core/src/main/java/org/certeasy/certspec/EmployeeIdentitySubject.java
+++ b/certeasy-core/src/main/java/org/certeasy/certspec/EmployeeIdentitySubject.java
@@ -8,7 +8,7 @@ import java.util.Set;
 public final class EmployeeIdentitySubject extends PersonalIdentitySubject {
 
     public EmployeeIdentitySubject(PersonName personName, GeographicAddress address, String telephone, String email, String username, OrganizationBinding organizationBinding) {
-        super(personName, address, telephone, Set.of(email), Set.of(username), organizationBinding);
+        super(personName, address, telephone, email!=null? Set.of(email) : null, username!=null? Set.of(username) : null, organizationBinding);
     }
 
 }

--- a/certeasy-core/src/main/java/org/certeasy/certspec/PersonalIdentitySubject.java
+++ b/certeasy-core/src/main/java/org/certeasy/certspec/PersonalIdentitySubject.java
@@ -17,21 +17,22 @@ public sealed class PersonalIdentitySubject extends CertificateSubject permits E
             throw new IllegalArgumentException("person commonName MUST not be null");
         if(address==null)
             throw new IllegalArgumentException("address MUST not be null");
-        if(emails==null || emails.isEmpty())
-            throw new IllegalArgumentException("emails set MUST not be null nor empty");
 
         DistinguishedName.Builder builder = DistinguishedName.builder();
         builder.append(personName);
         builder.append(address);
-        builder.append(new RelativeDistinguishedName(SubjectAttributeType.TELEPHONE_NUMBER, telephone));
+        if(telephone != null)
+            builder.append(new RelativeDistinguishedName(SubjectAttributeType.TELEPHONE_NUMBER, telephone));
 
         if(organizationBinding!=null)
             builder.append(organizationBinding);
 
         Set<SubjectAlternativeName> subjectAlternativeNames = new HashSet<>();
-        emails.stream()
-                .map(email -> new SubjectAlternativeName(SubjectAlternativeNameType.EMAIL, email))
-                .forEach(subjectAlternativeNames::add);
+        if(emails!= null && !emails.isEmpty()) {
+            emails.stream()
+                    .map(email -> new SubjectAlternativeName(SubjectAlternativeNameType.EMAIL, email))
+                    .forEach(subjectAlternativeNames::add);
+        }
         if(usernames!=null){
             usernames.stream()
                     .map(name -> new RelativeDistinguishedName(SubjectAttributeType.USER_ID,name))

--- a/certeasy-core/src/main/java/org/certeasy/certspec/PersonalIdentitySubject.java
+++ b/certeasy-core/src/main/java/org/certeasy/certspec/PersonalIdentitySubject.java
@@ -17,8 +17,6 @@ public sealed class PersonalIdentitySubject extends CertificateSubject permits E
             throw new IllegalArgumentException("person commonName MUST not be null");
         if(address==null)
             throw new IllegalArgumentException("address MUST not be null");
-        if(emails==null || emails.isEmpty())
-            throw new IllegalArgumentException("emails set MUST not be null nor empty");
 
         DistinguishedName.Builder builder = DistinguishedName.builder();
         builder.append(personName);
@@ -29,9 +27,11 @@ public sealed class PersonalIdentitySubject extends CertificateSubject permits E
             builder.append(organizationBinding);
 
         Set<SubjectAlternativeName> subjectAlternativeNames = new HashSet<>();
-        emails.stream()
-                .map(email -> new SubjectAlternativeName(SubjectAlternativeNameType.EMAIL, email))
-                .forEach(subjectAlternativeNames::add);
+        if(emails!= null && !emails.isEmpty()) {
+            emails.stream()
+                    .map(email -> new SubjectAlternativeName(SubjectAlternativeNameType.EMAIL, email))
+                    .forEach(subjectAlternativeNames::add);
+        }
         if(usernames!=null){
             usernames.stream()
                     .map(name -> new RelativeDistinguishedName(SubjectAttributeType.USER_ID,name))

--- a/certeasy-core/src/main/java/org/certeasy/certspec/TLSServerSubject.java
+++ b/certeasy-core/src/main/java/org/certeasy/certspec/TLSServerSubject.java
@@ -7,7 +7,9 @@ import java.util.stream.Collectors;
 
 public final class TLSServerSubject extends CertificateSubject {
 
-    public TLSServerSubject(Set<String> domains, GeographicAddress address, String organizationName){
+    public TLSServerSubject(String name, Set<String> domains, GeographicAddress address, String organizationName){
+        if(name==null || name.isEmpty())
+            throw new IllegalArgumentException("name MUST not be null nor empty");
         if(domains==null || domains.isEmpty())
             throw new IllegalArgumentException("domains MUST not be null nor empty");
         if(address==null)
@@ -16,7 +18,7 @@ public final class TLSServerSubject extends CertificateSubject {
                 .collect(Collectors.toSet());
         DistinguishedName.Builder dnBuilder =  DistinguishedName.builder();
         dnBuilder.append(new RelativeDistinguishedName(SubjectAttributeType.COMMON_NAME,
-                domains.iterator().next()));
+                name));
         if(organizationName!=null && !organizationName.isEmpty())
             dnBuilder.append(new RelativeDistinguishedName(SubjectAttributeType.ORGANIZATION_NAME,
                     organizationName));

--- a/certeasy-core/src/test/java/org/certeasy/certspec/PersonalIdentitySubjectTest.java
+++ b/certeasy-core/src/test/java/org/certeasy/certspec/PersonalIdentitySubjectTest.java
@@ -114,6 +114,19 @@ class PersonalIdentitySubjectTest {
     }
 
     @Test
+    @DisplayName("Create PersonalIdentitySubject with Empty Usernames")
+    void testCreatePersonalIdentitySubject_WithEmptyUsernames() {
+        // Arrange
+        PersonName personName = new PersonName("John", "Cina");
+        GeographicAddress address = new GeographicAddress("US", "New York", "Brooklyn", "123 Main St");
+        Set<String> emails = new HashSet<>();
+        Set<String> usernames = new HashSet<>();
+
+        new PersonalIdentitySubject(personName, address, "123-456-7898", emails, usernames);
+
+    }
+
+    @Test
     @DisplayName("Create PersonalIdentitySubject with Empty Emails")
     void testCreatePersonalIdentitySubject_WithEmptyEmails() {
         // Arrange
@@ -123,10 +136,7 @@ class PersonalIdentitySubjectTest {
         Set<String> usernames = new HashSet<>();
         usernames.add("johndoe");
 
-        // Assert
-        assertThrows(IllegalArgumentException.class, () -> {
-            // Act
-            new PersonalIdentitySubject(personName, address, "123-456-7890", emails, usernames);
-        });
+        new PersonalIdentitySubject(personName, address, "123-456-7890", emails, usernames);
+
     }
 }

--- a/certeasy-core/src/test/java/org/certeasy/certspec/TLSServerSubjectTest.java
+++ b/certeasy-core/src/test/java/org/certeasy/certspec/TLSServerSubjectTest.java
@@ -1,0 +1,46 @@
+package org.certeasy.certspec;
+
+
+import org.certeasy.GeographicAddress;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TLSServerSubjectTest {
+
+
+    @Test
+    public void must_fail_to_create_subject_with_null_name(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TLSServerSubject(null, Set.of("example.org"), new GeographicAddress("MZ", "Lorem", "Ipsum", "Dolor"),
+                    "Example Inc");
+        });
+    }
+
+
+    @Test
+    public void must_fail_to_create_subject_with_null_address(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TLSServerSubject("example", Set.of("example.org"), null,
+                    "Example Inc");
+        });
+    }
+
+    @Test
+    public void must_successfully_create_subject_without_organization_name(){
+        new TLSServerSubject("example", Set.of("example.org"), new GeographicAddress("MZ", "Lorem", "Ipsum", "Dolor"),
+                null);
+    }
+
+    @Test
+    public void must_fail_to_create_subject_with_empty_domains_set(){
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TLSServerSubject("example", Collections.emptySet(), new GeographicAddress("MZ", "Lorem", "Ipsum", "Dolor"),
+                    "Dummy Inc");
+        });
+    }
+
+}


### PR DESCRIPTION
## Changes

- Add name attribute to TLS Certificate spec to be used as CN
- Add support to issue personal certificates
- Add support to issue employee certificates