### PR TITLE
fix: escaping of RDN values

### DIFF
--- a/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfoFactory.java
+++ b/certeasy-backend-app/src/main/java/org/certeasy/backend/issuer/IssuerInfoFactory.java
@@ -22,10 +22,9 @@ public final class IssuerInfoFactory {
         String serial = certificate.getSerial();
         IssuerType issuerType = certificate.isSelfSignedCA() ? IssuerType.ROOT : IssuerType.SUB_CA;
         String distinguishedName = certificate.getDistinguishedName().toString();
-
         DistinguishedName issuerName = certificate.getIssuerName();
         IssuerParent parent = null;
-        if(!issuerName.equals(certificate.getDistinguishedName()))
+        if(issuerType==IssuerType.SUB_CA)
             parent = new IssuerParent(issuerName.digest(), issuerName.getCommonName());
         int totalChildren  = registry.countChildrenOf(issuer);
         return new IssuerInfo(id, certificate.getDistinguishedName().getCommonName(),  serial, issuerType,

--- a/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
+++ b/certeasy-backend-app/src/main/resources/META-INF/openapi.yaml
@@ -684,7 +684,7 @@ components:
           description: Whether the certificate is a certificate authority
         path_length:
           type: integer
-          description: The maximum depth of CAs that may exist below this CA. This limit is enforced when issuing a sub-ca certificate.
+          description: The maximum depth of CAs that may exist below this CA. This limit is NOT enforced when issuing a sub-ca certificate.
           default: 0
           minimum: 0
       required:

--- a/certeasy-core/src/main/java/org/certeasy/RelativeDistinguishedName.java
+++ b/certeasy-core/src/main/java/org/certeasy/RelativeDistinguishedName.java
@@ -21,7 +21,14 @@ public record RelativeDistinguishedName(SubjectAttributeType type, String value,
 
     @Override
     public String toString() {
-        return (type.getMnemonic() + "=" + value).replaceAll("(?<!\\\\),+", "\\\\,");
+        return (type.getMnemonic() + "=" + value)
+                .replaceAll("(?<!\\\\),+", "\\\\,")
+                .replaceAll("(?<!\\\\)\\++", "\\\\+")
+                .replaceAll("(?<!\\\\)>+", "\\\\>")
+                .replaceAll("(?<!\\\\)<+", "\\\\<")
+                .replaceAll("(?<!\\\\)\"+", "\\\\\"")
+                .replaceAll("(?<!\\\\)\\+", "\\\\\\")
+                .replaceAll("(?<!\\\\)#+", "\\\\#");
     }
 
     @Override

--- a/certeasy-core/src/test/java/org/certeasy/RelativeDistinguishedNameTest.java
+++ b/certeasy-core/src/test/java/org/certeasy/RelativeDistinguishedNameTest.java
@@ -4,17 +4,73 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+
+import static org.junit.jupiter.api.Assertions.*;
 class RelativeDistinguishedNameTest {
 
     @Test
-    @DisplayName("toString() must return desired output")
-    void toStringMustProduceDesiredOutput(){
+    @DisplayName("toString() must escape plus sign")
+    void toStringMustEscapePlusSign(){
 
-        String userId = "123456789";
-        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.USER_ID,userId);
-        Assertions.assertEquals(String.format("%s=%s", SubjectAttributeType.USER_ID.getMnemonic(), userId),
-                rdn.toString());
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario+Junior");
+        System.out.println(rdn.toString());
+        assertEquals("G=Mario\\+Junior", rdn.toString());
 
     }
+
+    @Test
+    @DisplayName("toString() must escape back slash")
+    void toStringMustEscapeBackSlash(){
+
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario\\Junior");
+        assertEquals("G=Mario\\Junior", rdn.toString());
+
+    }
+
+    @Test
+    @DisplayName("toString() must escape pound")
+    void toStringMustEscapePound(){
+
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario#Junior");
+        assertEquals("G=Mario\\#Junior", rdn.toString());
+
+    }
+
+    @Test
+    @DisplayName("toString() must escape double quote")
+    void toStringMustEscapeDoubleQuote(){
+
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario\"Junior");
+        assertEquals("G=Mario\\\"Junior", rdn.toString());
+
+    }
+
+    @Test
+    @DisplayName("toString() must escape greater than")
+    void toStringMustEscapeGreaterThan(){
+
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario>Junior");
+        assertEquals("G=Mario\\>Junior", rdn.toString());
+
+    }
+
+    @Test
+    @DisplayName("toString() must escape less than")
+    void toStringMustEscapeLessThan(){
+
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario<Junior");
+        assertEquals("G=Mario\\<Junior", rdn.toString());
+
+    }
+
+    @Test
+    @DisplayName("toString() must escape comma")
+    void toStringMustEscapeComma(){
+
+        RelativeDistinguishedName rdn = new RelativeDistinguishedName(SubjectAttributeType.GIVEN_NAME,"Mario,Junior");
+        assertEquals("G=Mario\\,Junior", rdn.toString());
+
+    }
+
 
 }


### PR DESCRIPTION
This fix will address the issue of the backend classifying a ROOT Issuer as a SUB_CA issuer mistakenly